### PR TITLE
Add character subpiece transformation

### DIFF
--- a/src/processTargets.ts
+++ b/src/processTargets.ts
@@ -214,10 +214,11 @@ function transformSelection(
       }
 
       // NB: We use the modulo here to handle negative offsets
-      const endIndex =
+      let endIndex =
         transformation.endIndex == null
           ? pieces.length
           : (transformation.endIndex + pieces.length) % pieces.length;
+      endIndex = endIndex === 0 ? pieces.length : endIndex;
       const startIndex =
         (transformation.startIndex + pieces.length) % pieces.length;
 


### PR DESCRIPTION
I needed some work to do with the extension and I noticed a 'good first issue' label on #23, so I thought I'd take a stab at it.

Turns out this code also involves the bug I reported with indicating the last subpiece by its index #9, so I included a commit for that as well. This was caused by the `endIndex` getting wrapped to 0, so I added an explicit check which will reset it back to the max value. This assumes `endIndex` doesn't ever need to be 0, which I think is a safe assumption? 

Hopefully this is helpful! Let me know if you'd approach any of this differently!

Closes #9 
Closes #23 