### PR TITLE
Updated regular expression for sub word matcher and added additional …

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const SUBWORD_MATCHER = /([A-Z]?[a-z]+|[A-Za-z]+)/g;
+export const SUBWORD_MATCHER = /[A-Z]?[a-z]+|[A-Z]+(?![a-z])|[0-9]+/g;
 
 export const DEBOUNCE_DELAY = 175;
 

--- a/src/test/suite/constants.test.ts
+++ b/src/test/suite/constants.test.ts
@@ -3,10 +3,10 @@ import * as assert from "assert";
 import { SUBWORD_MATCHER } from "../../constants";
 import { subwordFixture } from "./fixtures/constants.fixture";
 
-suite.only("subword regex matcher", () => {
+suite("subword regex matcher", () => {
   subwordFixture.forEach(({ input, expectedOutput }, index) => {
     test(input, () => {
-      assert.deepStrictEqual(expectedOutput, input.match(SUBWORD_MATCHER));
+      assert.deepStrictEqual(input.match(SUBWORD_MATCHER), expectedOutput);
     });
   });
 });

--- a/src/test/suite/fixtures/constants.fixture.ts
+++ b/src/test/suite/fixtures/constants.fixture.ts
@@ -52,14 +52,20 @@ export const subwordFixture: Fixture[] = [
     input: "QUICK::BROWN::FOX",
     expectedOutput: ["QUICK", "BROWN", "FOX"],
   },
-  // Not currently handled properly: https://github.com/pokey/cursorless-vscode/issues/79
   {
     input: "APIClientFactory",
-    expectedOutput: ["APIClientFactory"],
+    expectedOutput: ["API", "Client", "Factory"],
   },
-  // Not currently handled properly: https://github.com/pokey/cursorless-vscode/issues/79
   {
     input: "MockAPIClientFactory",
-    expectedOutput: ["Mock", "APIClientFactory"],
+    expectedOutput: ["Mock", "API", "Client", "Factory"],
   },
+  {
+    input: "mockAPIClientFactory",
+    expectedOutput: ["mock", "API", "Client", "Factory"],
+  },
+  {
+    input: "mockAPIClient123Factory",
+    expectedOutput: ["mock", "API", "Client", "123", "Factory"],
+  }
 ];

--- a/src/test/suite/tokenizer.test.ts
+++ b/src/test/suite/tokenizer.test.ts
@@ -42,7 +42,7 @@ const tests: TestCase[] = [
 
 suite("tokenizer", () => {
   tests.forEach(([input, expectedOutput]) => {
-    test(`tokenizer ${input}`, () => {
+    test(input, () => {
       const output = tokenize(input, (match) => match[0]);
       assert.deepStrictEqual(output, expectedOutput);
     });


### PR DESCRIPTION
…tests

Subword matcher can now correctly match tokens like:
"mockAPIClient123Factory" => ["mock", "API", "Client", "123", "Factory"]

Fixes issue #79 