### PR TITLE
Add support for untrusted workspaces

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,11 @@
 		"*"
 	],
 	"main": "./dist/extension.js",
+	"capabilities": {
+		"untrustedWorkspaces": {
+			"supported": true
+		}
+	},
 	"contributes": {
 		"commands": [
 			{


### PR DESCRIPTION
This extension should be safe to use in untrusted workspaces; it has no vulnerable settings and doesn't try to execute any code from the workspace