### PR TITLE
Added action set breakpoint

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -250,6 +250,7 @@ export type ActionType =
   | "scrollToBottom"
   | "scrollToCenter"
   | "scrollToTop"
+  | "setBreakpoint"
   | "setSelection"
   | "setSelectionAfter"
   | "setSelectionBefore"

--- a/src/actions/SetBreakpoint.ts
+++ b/src/actions/SetBreakpoint.ts
@@ -1,0 +1,81 @@
+import {
+  Action,
+  ActionPreferences,
+  ActionReturnValue,
+  Graph,
+  TypedSelection,
+} from "../Types";
+import {
+  SourceBreakpoint,
+  Location,
+  debug,
+  Uri,
+  Range,
+  Breakpoint,
+} from "vscode";
+import displayPendingEditDecorations from "../editDisplayUtils";
+
+function getBreakpoint(uri: Uri, line: number) {
+  return debug.breakpoints.find((breakpoint) => {
+    if (breakpoint instanceof SourceBreakpoint) {
+      return (
+        (breakpoint as SourceBreakpoint).location.uri.toString() ===
+          uri.toString() &&
+        (breakpoint as SourceBreakpoint).location.range.start.line === line
+      );
+    }
+    return false;
+  });
+}
+
+export default class SetBreakpoint implements Action {
+  targetPreferences: ActionPreferences[] = [{ insideOutsideType: "inside" }];
+
+  constructor(private graph: Graph) {
+    this.run = this.run.bind(this);
+  }
+
+  async run([targets]: [
+    TypedSelection[],
+    TypedSelection[]
+  ]): Promise<ActionReturnValue> {
+    await displayPendingEditDecorations(
+      targets,
+      this.graph.editStyles.referenced,
+      this.graph.editStyles.referencedLine
+    );
+
+    const lines = targets.flatMap((target) => {
+      const { start, end } = target.selection.selection;
+      const lines = [];
+      for (let i = start.line; i <= end.line; ++i) {
+        lines.push({
+          uri: target.selection.editor.document.uri,
+          line: i,
+        });
+      }
+      return lines;
+    });
+
+    const toAdd: Breakpoint[] = [];
+    const toRemove: Breakpoint[] = [];
+
+    lines.forEach(({ uri, line }) => {
+      const existing = getBreakpoint(uri, line);
+      if (existing) {
+        toRemove.push(existing);
+      } else {
+        toAdd.push(
+          new SourceBreakpoint(new Location(uri, new Range(line, 0, line, 0)))
+        );
+      }
+    });
+
+    debug.addBreakpoints(toAdd);
+    debug.removeBreakpoints(toRemove);
+
+    const thatMark = targets.map((target) => target.selection);
+
+    return { returnValue: null, thatMark };
+  }
+}

--- a/src/actions/index.ts
+++ b/src/actions/index.ts
@@ -19,6 +19,7 @@ import Paste from "./Paste";
 import { Bring, Move, Swap } from "./BringMoveSwap";
 import GetText from "./GetText";
 import { FindInFiles } from "./Find";
+import SetBreakpoint from "./SetBreakpoint";
 
 class Actions implements ActionRecord {
   constructor(private graph: Graph) {}
@@ -45,6 +46,7 @@ class Actions implements ActionRecord {
   scrollToBottom = new ScrollToBottom(this.graph);
   scrollToCenter = new ScrollToCenter(this.graph);
   scrollToTop = new ScrollToTop(this.graph);
+  setBreakpoint = new SetBreakpoint(this.graph);
   setSelection = new SetSelection(this.graph);
   setSelectionAfter = new SetSelectionAfter(this.graph);
   setSelectionBefore = new SetSelectionBefore(this.graph);


### PR DESCRIPTION
@pokey 
When starting a new debug session `debug.breakpoints` is empty even though I can see old breakpoints besides the lines. This makes it so you can't remove existing breakpoints for a few attempts. After that it all works fine.