### PR TITLE
Added leading and trailing delimiters to subtoken

### DIFF
--- a/src/processTargets.ts
+++ b/src/processTargets.ts
@@ -284,12 +284,50 @@ function transformSelection(
         isReversed ? pieces[activeIndex].start : pieces[activeIndex].end
       );
 
+      const startIndex = Math.min(anchorIndex, activeIndex);
+      const endIndex = Math.max(anchorIndex, activeIndex);
+      const leadingDelimiterRange =
+        startIndex > 0 && pieces[startIndex - 1].end < pieces[startIndex].start
+          ? new Range(
+              selection.selection.start.translate({
+                characterDelta: pieces[startIndex - 1].end,
+              }),
+              selection.selection.start.translate({
+                characterDelta: pieces[startIndex].start,
+              })
+            )
+          : null;
+      const trailingDelimiterRange =
+        endIndex + 1 < pieces.length &&
+        pieces[endIndex].end < pieces[endIndex + 1].start
+          ? new Range(
+              selection.selection.start.translate({
+                characterDelta: pieces[endIndex].end,
+              }),
+              selection.selection.start.translate({
+                characterDelta: pieces[endIndex + 1].start,
+              })
+            )
+          : null;
+      const isInDelimitedList =
+        leadingDelimiterRange != null || trailingDelimiterRange != null;
+      const containingListDelimiter = isInDelimitedList
+        ? selection.editor.document.getText(
+            (leadingDelimiterRange ?? trailingDelimiterRange)!
+          )
+        : null;
+
       return [
         {
           selection: update(selection, {
             selection: () => new Selection(anchor, active),
           }),
-          context: {},
+          context: {
+            isInDelimitedList,
+            containingListDelimiter: containingListDelimiter ?? undefined,
+            leadingDelimiterRange,
+            trailingDelimiterRange,
+          },
         },
       ];
     case "matchingPairSymbol":

--- a/src/test/suite/fixtures/recorded/subtoken/chuckFirstCharVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/chuckFirstCharVest.yml
@@ -1,0 +1,32 @@
+spokenForm: chuck first char vest
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: character, anchor: 0, active: 0}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const alue_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: character, anchor: 0, active: 0}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/subtoken/chuckFirstWordVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/chuckFirstWordVest.yml
@@ -1,0 +1,32 @@
+spokenForm: chuck first word vest
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: word, anchor: 0, active: 0}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: word, anchor: 0, active: 0}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/subtoken/chuckLastCharVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/chuckLastCharVest.yml
@@ -1,0 +1,32 @@
+spokenForm: chuck last char vest
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: character, anchor: -1, active: -1}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const value_hello_st = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 20}
+      active: {line: 1, character: 20}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: character, anchor: -1, active: -1}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/subtoken/chuckLastWordVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/chuckLastWordVest.yml
@@ -1,0 +1,32 @@
+spokenForm: chuck last word vest
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: word, anchor: -1, active: -1}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const value_hello = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 17}
+      active: {line: 1, character: 17}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: word, anchor: -1, active: -1}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/subtoken/chuckSecondWordVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/chuckSecondWordVest.yml
@@ -1,0 +1,32 @@
+spokenForm: chuck second word vest
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: word, anchor: 1, active: 1}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const value_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: word, anchor: 1, active: 1}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/subtoken/chuckSixthCharVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/chuckSixthCharVest.yml
@@ -1,0 +1,32 @@
+spokenForm: chuck sixth char vest
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: character, anchor: 5, active: 5}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const valuehello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: character, anchor: 5, active: 5}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/subtoken/clearFirstCharVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/clearFirstCharVest.yml
@@ -1,0 +1,32 @@
+spokenForm: clear first char vest
+languageId: typescript
+command:
+  actionName: clear
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: character, anchor: 0, active: 0}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const alue_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+  thatMark:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: character, anchor: 0, active: 0}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/subtoken/clearFirstWordVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/clearFirstWordVest.yml
@@ -1,0 +1,32 @@
+spokenForm: clear first word vest
+languageId: typescript
+command:
+  actionName: clear
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: word, anchor: 0, active: 0}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const _hello_str = "Hello world";
+  selections:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+  thatMark:
+    - anchor: {line: 1, character: 6}
+      active: {line: 1, character: 6}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: word, anchor: 0, active: 0}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/subtoken/clearLastCharVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/clearLastCharVest.yml
@@ -1,0 +1,32 @@
+spokenForm: clear last char vest
+languageId: typescript
+command:
+  actionName: clear
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: character, anchor: -1, active: -1}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const value_hello_st = "Hello world";
+  selections:
+    - anchor: {line: 1, character: 20}
+      active: {line: 1, character: 20}
+  thatMark:
+    - anchor: {line: 1, character: 20}
+      active: {line: 1, character: 20}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: character, anchor: -1, active: -1}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/subtoken/clearLastWordVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/clearLastWordVest.yml
@@ -1,0 +1,32 @@
+spokenForm: clear last word vest
+languageId: typescript
+command:
+  actionName: clear
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: word, anchor: -1, active: -1}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const value_hello_ = "Hello world";
+  selections:
+    - anchor: {line: 1, character: 18}
+      active: {line: 1, character: 18}
+  thatMark:
+    - anchor: {line: 1, character: 18}
+      active: {line: 1, character: 18}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: word, anchor: -1, active: -1}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/subtoken/clearSecondWordVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/clearSecondWordVest.yml
@@ -1,0 +1,32 @@
+spokenForm: clear second word vest
+languageId: typescript
+command:
+  actionName: clear
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: word, anchor: 1, active: 1}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const value__str = "Hello world";
+  selections:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+  thatMark:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: word, anchor: 1, active: 1}, insideOutsideType: inside}]

--- a/src/test/suite/fixtures/recorded/subtoken/clearSixthCharVest.yml
+++ b/src/test/suite/fixtures/recorded/subtoken/clearSixthCharVest.yml
@@ -1,0 +1,32 @@
+spokenForm: clear sixth char vest
+languageId: typescript
+command:
+  actionName: clear
+  partialTargets:
+    - type: primitive
+      modifier: {type: subpiece, pieceType: character, anchor: 5, active: 5}
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 21}
+initialState:
+  documentContents: |
+
+    const value_hello_str = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |
+
+    const valuehello_str = "Hello world";
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+  thatMark:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+returnValue: null
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: token, position: contents, modifier: {type: subpiece, pieceType: character, anchor: 5, active: 5}, insideOutsideType: inside}]


### PR DESCRIPTION
`chuck second word air` well now remove the underscore in a snake case token.