### PR TITLE
Test on PR and push to master

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: Run Tests
+permissions: read-all
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches: master
+    types: [opened, synchronize, reopened]
+
+jobs:
+  test:
+    name: Test
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: xvfb-run -a yarn test
+        if: runner.os == 'Linux'
+      - run: yarn test
+        if: runner.os != 'Linux'

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
 		"test-compile": "tsc -p ./",
 		"compile": "tsc -p ./",
 		"watch": "tsc -watch -p ./",
-		"pretest": "yarn run compile && yarn run lint",
+		"pretest": "yarn run compile && yarn run lint && yarn run esbuild",
 		"lint": "eslint src --ext ts",
 		"test": "node ./out/test/runTest.js"
 	},

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,6 +1,11 @@
 import * as path from "path";
+import * as cp from "child_process";
 
-import { runTests } from "vscode-test";
+import {
+  runTests,
+  resolveCliPathFromVSCodeExecutablePath,
+  downloadAndUnzipVSCode,
+} from "vscode-test";
 
 async function main() {
   try {
@@ -12,11 +17,21 @@ async function main() {
     // Passed to --extensionTestsPath
     const extensionTestsPath = path.resolve(__dirname, "./suite/index");
 
-    // Download VS Code, unzip it and run the integration test
+    const vscodeExecutablePath = await downloadAndUnzipVSCode();
+    const cliPath =
+      resolveCliPathFromVSCodeExecutablePath(vscodeExecutablePath);
+
+    // Install extension dependencies
+    cp.spawnSync(cliPath, ["--install-extension", "pokey.parse-tree"], {
+      encoding: "utf-8",
+      stdio: "inherit",
+    });
+
+    // Run the integration test
     await runTests({
+      vscodeExecutablePath,
       extensionDevelopmentPath,
       extensionTestsPath,
-      launchArgs: ["--disable-extensions"],
     });
   } catch (err) {
     console.error("Failed to run tests");

--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -33,7 +33,7 @@ suite("recorded test cases", async function () {
     __dirname,
     "../../../src/test/suite/fixtures/recorded"
   );
-  const files = await walkFilesSync(directory);
+  const files = walkFilesSync(directory);
 
   teardown(() => {
     sinon.restore();
@@ -82,6 +82,7 @@ suite("recorded test cases", async function () {
 
       // Wait for cursorless to set up decorations
       cursorlessApi.addDecorations();
+      await new Promise((resolve) => setTimeout(resolve, 100));
 
       // Assert that recorded decorations are present
       Object.entries(fixture.marks).forEach(([key, token]) => {


### PR DESCRIPTION
This runs tests for linux, mac, and windows on every PR and push to master.

Tests occasionally flake out, it seems like adding a 100ms wait after decoration set up solves this. I've run the tests a few times successfully now. The timeout could be smaller, but things are pretty bad on the macos runner which is pretty dang slow. I'm guessing because of this:
```
Unable to create basic Accelerated OpenGL renderer.

Core Image is now using the software OpenGL renderer. This will be slow.
```

[From what I've been able to read](https://github.com/actions/virtual-environments/issues?q=is%3Aissue+sort%3Aupdated-desc+macos+opengl+is%3Aclosed), it doesn't seem like we're going to be able to do much about that...?

