### PR TITLE
Updated how line decorations are shown

### DIFF
--- a/src/Types.ts
+++ b/src/Types.ts
@@ -217,7 +217,9 @@ export interface SelectionContext {
   isInDelimitedList?: boolean;
   containingListDelimiter?: string | null;
 
-  // Selection used for outside selection
+  /**
+   * Selection used for outside selection
+   */
   outerSelection?: vscode.Selection | null;
 
   /**

--- a/src/actions/InsertEmptyLines.ts
+++ b/src/actions/InsertEmptyLines.ts
@@ -52,23 +52,29 @@ class InsertEmptyLines implements Action {
         const ranges = this.getRanges(targets);
         const edits = this.getEdits(ranges);
 
-        const [updatedSelections, lineSelections] =
+        const [updatedSelections, lineSelections, updatedOriginalSelections] =
           await performEditsAndUpdateSelections(editor, edits, [
             targets.map((target) => target.selection.selection),
             ranges.map((range) => new Selection(range.start, range.end)),
+            editor.selections,
           ]);
+
+        editor.selections = updatedOriginalSelections;
 
         return {
           thatMark: updatedSelections.map((selection) => ({
             editor,
             selection,
           })),
-          lineSelections: lineSelections.map((selection) => ({
+          lineSelections: lineSelections.map((selection, index) => ({
             editor,
-            selection: new Selection(
-              selection.start.translate({ lineDelta: -1 }),
-              selection.end.translate({ lineDelta: -1 })
-            ),
+            selection:
+              ranges[index].start.line < editor.document.lineCount - 1
+                ? new Selection(
+                    selection.start.translate({ lineDelta: -1 }),
+                    selection.end.translate({ lineDelta: -1 })
+                  )
+                : selection,
           })),
         };
       })

--- a/src/editDisplayUtils.ts
+++ b/src/editDisplayUtils.ts
@@ -63,14 +63,14 @@ export default async function displayPendingEditDecorations(
           const { start, end } = selection.selection.selection;
           const startLine = document.lineAt(start);
           const hasLeadingLine = start.character === startLine.range.end.character;
-          if (end.character === 0 && (!leadingLine || start.character === 0)) {
+          if (end.character === 0 && (!hasLeadingLine || start.character === 0)) {
             // NB: We move end up one line because it is at beginning of
             // next line
             return selection.selection.selection.with({
               end: end.translate(-1),
             });
           }
-          if (leadingLine) {
+          if (hasLeadingLine) {
             // NB: We move start down one line because it is at end of
             // previous line
             return selection.selection.selection.with({

--- a/src/editDisplayUtils.ts
+++ b/src/editDisplayUtils.ts
@@ -59,23 +59,23 @@ export default async function displayPendingEditDecorations(
       selections
         .filter((selection) => isLineSelectionType(selection.selectionType))
         .map((selection) => {
-          const start = selection.selection.selection.start;
-          const startLine = selection.selection.editor.document.lineAt(start);
-          if (start.character === startLine.range.end.character) {
-            return selection.selection.selection.with(
-              // NB: We move start down one line because it is at end of
-              // previous line
-              selection.selection.selection.start.translate(1),
-              undefined
-            );
+          const { document } = selection.selection.editor;
+          const { start, end } = selection.selection.selection;
+          const startLine = document.lineAt(start);
+          const leadingLine = start.character === startLine.range.end.character;
+          if (end.character === 0 && (!leadingLine || start.character === 0)) {
+            // NB: We move end up one line because it is at beginning of
+            // next line
+            return selection.selection.selection.with({
+              end: end.translate(-1),
+            });
           }
-          if (selection.selection.selection.end.character === 0) {
-            return selection.selection.selection.with(
-              undefined,
-              // NB: We move end up one line because it is at beginning of
-              // next line
-              selection.selection.selection.end.translate(-1)
-            );
+          if (leadingLine) {
+            // NB: We move start down one line because it is at end of
+            // previous line
+            return selection.selection.selection.with({
+              start: start.translate(1),
+            });
           }
           return selection.selection.selection;
         })

--- a/src/editDisplayUtils.ts
+++ b/src/editDisplayUtils.ts
@@ -62,7 +62,7 @@ export default async function displayPendingEditDecorations(
           const { document } = selection.selection.editor;
           const { start, end } = selection.selection.selection;
           const startLine = document.lineAt(start);
-          const leadingLine = start.character === startLine.range.end.character;
+          const hasLeadingLine = start.character === startLine.range.end.character;
           if (end.character === 0 && (!leadingLine || start.character === 0)) {
             // NB: We move end up one line because it is at beginning of
             // next line

--- a/src/editDisplayUtils.ts
+++ b/src/editDisplayUtils.ts
@@ -50,20 +50,24 @@ export default async function displayPendingEditDecorations(
     editor.setDecorations(
       editStyle.token,
       selections
-        .filter((selection) => !isLineSelectionType(selection.selectionType))
+        .filter((selection) => !useLineDecorations(selection))
         .map((selection) => selection.selection.selection)
     );
 
     editor.setDecorations(
       editStyle.line,
       selections
-        .filter((selection) => isLineSelectionType(selection.selectionType))
+        .filter((selection) => useLineDecorations(selection))
         .map((selection) => {
           const { document } = selection.selection.editor;
           const { start, end } = selection.selection.selection;
           const startLine = document.lineAt(start);
-          const hasLeadingLine = start.character === startLine.range.end.character;
-          if (end.character === 0 && (!hasLeadingLine || start.character === 0)) {
+          const hasLeadingLine =
+            start.character === startLine.range.end.character;
+          if (
+            end.character === 0 &&
+            (!hasLeadingLine || start.character === 0)
+          ) {
             // NB: We move end up one line because it is at beginning of
             // next line
             return selection.selection.selection.with({
@@ -131,5 +135,12 @@ export async function displayDecorationsWhileRunningFunc(
     async (editor) => {
       editor.setDecorations(decorationType, []);
     }
+  );
+}
+
+function useLineDecorations(selection: TypedSelection) {
+  return (
+    isLineSelectionType(selection.selectionType) &&
+    selection.position === "contents"
   );
 }

--- a/src/performInsideOutsideAdjustment.ts
+++ b/src/performInsideOutsideAdjustment.ts
@@ -4,7 +4,7 @@ import { updateTypedSelectionRange } from "./selectionUtils";
 export function performInsideOutsideAdjustment(
   selection: TypedSelection,
   preferredInsideOutsideType: InsideOutsideType = null
-) {
+): TypedSelection {
   const insideOutsideType =
     selection.insideOutsideType ?? preferredInsideOutsideType;
 

--- a/src/test/suite/fixtures/recorded/positions/chuckAfterBlockVest.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckAfterBlockVest.yml
@@ -1,0 +1,34 @@
+spokenForm: chuck after block vest
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      position: after
+      selectionType: paragraph
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 11}
+initialState:
+  documentContents: |-
+
+    const value = "Hello world";
+
+        const value = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |-
+
+    const value = "Hello world";    const value = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 28}
+      active: {line: 1, character: 28}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: paragraph, position: after, modifier: {type: identity}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/positions/chuckAfterLineVest.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckAfterLineVest.yml
@@ -1,0 +1,35 @@
+spokenForm: chuck after line vest
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      position: after
+      selectionType: line
+      mark: {type: decoratedSymbol, symbolColor: default, character: v}
+  extraArgs: []
+marks:
+  default.v:
+    start: {line: 1, character: 6}
+    end: {line: 1, character: 11}
+initialState:
+  documentContents: |-
+
+    const value = "Hello world";
+
+        const value = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |-
+
+    const value = "Hello world";
+        const value = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 28}
+      active: {line: 1, character: 28}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: v}, selectionType: line, position: after, modifier: {type: identity}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/positions/chuckBeforeBlockAir.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckBeforeBlockAir.yml
@@ -1,0 +1,34 @@
+spokenForm: chuck before block air
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      position: before
+      selectionType: paragraph
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  extraArgs: []
+marks:
+  default.a:
+    start: {line: 3, character: 10}
+    end: {line: 3, character: 15}
+initialState:
+  documentContents: |-
+
+    const value = "Hello world";
+
+        const value = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |-
+
+    const value = "Hello world";    const value = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 28}
+      active: {line: 1, character: 28}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: paragraph, position: before, modifier: {type: identity}, insideOutsideType: outside}]

--- a/src/test/suite/fixtures/recorded/positions/chuckBeforeLineAir.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckBeforeLineAir.yml
@@ -1,0 +1,35 @@
+spokenForm: chuck before line air
+languageId: typescript
+command:
+  actionName: delete
+  partialTargets:
+    - type: primitive
+      position: before
+      selectionType: line
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  extraArgs: []
+marks:
+  default.a:
+    start: {line: 3, character: 10}
+    end: {line: 3, character: 15}
+initialState:
+  documentContents: |-
+
+    const value = "Hello world";
+
+        const value = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+finalState:
+  documentContents: |-
+
+    const value = "Hello world";
+        const value = "Hello world";
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  thatMark:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: line, position: before, modifier: {type: identity}, insideOutsideType: outside}]


### PR DESCRIPTION
* Line decorations are now always shown for the correct line
* Decorations for line/paragraph with position before/after uses non line decoration. 
    - This means that the decorations aren't shown for empty lines
* Before line and paragraph are adjusted to not include indentations on line with text
    - `chuck before line` keeps indentation
* Fixed line decoration on float command 