### PR TITLE
Fix cross-split selections

### DIFF
--- a/src/setSelectionsAndFocusEditor.ts
+++ b/src/setSelectionsAndFocusEditor.ts
@@ -18,10 +18,12 @@ export async function setSelectionsAndFocusEditor(
   editor: TextEditor,
   selections: Selection[]
 ) {
-  await focusEditor(editor);
-
   editor.selections = selections;
-  editor.revealRange(editor.selections[0]);
+  editor.revealRange(editor.selection);
+
+  // NB: We focus the editor after setting the selection because otherwise you see
+  // an intermediate state where the old selection persists
+  await focusEditor(editor);
 }
 
 export async function focusEditor(editor: TextEditor) {


### PR DESCRIPTION
We now focus the editor after setting the selection because otherwise you see an intermediate state where the old selection persists