### PR TITLE
Fix copy when focus is not on editor

### DIFF
--- a/src/actions/CommandAction.ts
+++ b/src/actions/CommandAction.ts
@@ -35,14 +35,14 @@ export default class CommandAction implements Action {
       await runOnTargetsForEachEditor<SelectionWithEditor[]>(
         targets,
         async (editor, targets) => {
+          const originalSelections = editor.selections;
+
           const targetSelections = targets.map(
             (target) => target.selection.selection
           );
 
           // For command to the work we have to have the correct editor focused
           await setSelectionsAndFocusEditor(editor, targetSelections, false);
-
-          const originalSelections = editor.selections;
 
           const [updatedOriginalSelections, updatedTargetSelections] =
             await callFunctionAndUpdateSelections(

--- a/src/actions/CommandAction.ts
+++ b/src/actions/CommandAction.ts
@@ -9,7 +9,10 @@ import {
 } from "../typings/Types";
 import displayPendingEditDecorations from "../util/editDisplayUtils";
 import { runOnTargetsForEachEditor } from "../util/targetUtils";
-import { focusEditor } from "../util/setSelectionsAndFocusEditor";
+import {
+  focusEditor,
+  setSelectionsAndFocusEditor,
+} from "../util/setSelectionsAndFocusEditor";
 import { flatten } from "lodash";
 import { callFunctionAndUpdateSelections } from "../util/updateSelections";
 import { ensureSingleEditor } from "../util/targetUtils";
@@ -32,18 +35,14 @@ export default class CommandAction implements Action {
       await runOnTargetsForEachEditor<SelectionWithEditor[]>(
         targets,
         async (editor, targets) => {
-          // For command to the work we have to have the correct editor focused
-          if (editor !== window.activeTextEditor) {
-            await focusEditor(editor);
-          }
-
-          const originalSelections = editor.selections;
-
           const targetSelections = targets.map(
             (target) => target.selection.selection
           );
 
-          editor.selections = targetSelections;
+          // For command to the work we have to have the correct editor focused
+          await setSelectionsAndFocusEditor(editor, targetSelections, false);
+
+          const originalSelections = editor.selections;
 
           const [updatedOriginalSelections, updatedTargetSelections] =
             await callFunctionAndUpdateSelections(

--- a/src/util/setSelectionsAndFocusEditor.ts
+++ b/src/util/setSelectionsAndFocusEditor.ts
@@ -16,10 +16,14 @@ const columnFocusCommands = {
 
 export async function setSelectionsAndFocusEditor(
   editor: TextEditor,
-  selections: Selection[]
+  selections: Selection[],
+  revealRange: boolean = true
 ) {
   editor.selections = selections;
-  editor.revealRange(editor.selection);
+
+  if (revealRange) {
+    editor.revealRange(editor.selection);
+  }
 
   // NB: We focus the editor after setting the selection because otherwise you see
   // an intermediate state where the old selection persists


### PR DESCRIPTION
Unfortunately, we aren't able to set focus back to where it was before, eg a search box.  Maybe this argues for switching back to our own copy implementation?