### PR TITLE
Rename purple to pink

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,8 +165,8 @@
 						"highContrast": "#f0b800"
 					}
 				},
-				"cursorless.colors.purple": {
-					"description": "Color to use for purple symbols",
+				"cursorless.colors.pink": {
+					"description": "Color to use for pink symbols",
 					"type": "object",
 					"default": {
 						"dark": "#de25ff",
@@ -199,7 +199,7 @@
 						"yellow": {
 							"type": "boolean"
 						},
-						"purple": {
+						"pink": {
 							"type": "boolean"
 						}
 					},
@@ -208,7 +208,7 @@
 						"green": true,
 						"red": true,
 						"yellow": true,
-						"purple": true
+						"pink": true
 					},
 					"additionalProperties": false
 				},
@@ -265,7 +265,7 @@
 						"yellow": {
 							"type": "number"
 						},
-						"purple": {
+						"pink": {
 							"type": "number"
 						}
 					},
@@ -274,7 +274,7 @@
 						"green": 1,
 						"red": 1,
 						"yellow": 1,
-						"purple": 1
+						"pink": 1
 					},
 					"additionalProperties": false
 				},

--- a/src/canonicalizeTargets.ts
+++ b/src/canonicalizeTargets.ts
@@ -8,13 +8,13 @@ import { transformPrimitiveTargets } from "./util/targetUtils";
 import { HatStyleName } from "./core/constants";
 import { flow } from "lodash";
 
-const scopeTypeAliasToCanonicalName: Record<string, ScopeType> = {
+const SCOPE_TYPE_CANONICALIZATION_MAPPING: Record<string, ScopeType> = {
   arrowFunction: "anonymousFunction",
   dictionary: "map",
   regex: "regularExpression",
 };
 
-const colorAliasToCanonicalName: Record<string, HatStyleName> = {
+const COLOR_CANONICALIZATION_MAPPING: Record<string, HatStyleName> = {
   purple: "pink",
 };
 
@@ -25,7 +25,7 @@ const canonicalizeScopeTypes = (
     ? update(target, {
         modifier: {
           scopeType: (scopeType: string) =>
-            scopeTypeAliasToCanonicalName[scopeType] ?? scopeType,
+            SCOPE_TYPE_CANONICALIZATION_MAPPING[scopeType] ?? scopeType,
         },
       })
     : target;
@@ -37,7 +37,7 @@ const canonicalizeColors = (
     ? update(target, {
         mark: {
           symbolColor: (symbolColor: string) =>
-            colorAliasToCanonicalName[symbolColor] ?? symbolColor,
+            COLOR_CANONICALIZATION_MAPPING[symbolColor] ?? symbolColor,
         },
       })
     : target;

--- a/src/canonicalizeTargets.ts
+++ b/src/canonicalizeTargets.ts
@@ -1,6 +1,12 @@
-import { PartialTarget, ScopeType } from "./typings/Types";
+import {
+  PartialPrimitiveTarget,
+  PartialTarget,
+  ScopeType,
+} from "./typings/Types";
 import update from "immutability-helper";
 import { transformPrimitiveTargets } from "./util/targetUtils";
+import { HatStyleName } from "./core/constants";
+import { flow } from "lodash";
 
 const scopeTypeAliasToCanonicalName: Record<string, ScopeType> = {
   arrowFunction: "anonymousFunction",
@@ -8,15 +14,37 @@ const scopeTypeAliasToCanonicalName: Record<string, ScopeType> = {
   regex: "regularExpression",
 };
 
+const colorAliasToCanonicalName: Record<string, HatStyleName> = {
+  purple: "pink",
+};
+
+const canonicalizeScopeTypes = (
+  target: PartialPrimitiveTarget
+): PartialPrimitiveTarget =>
+  target.modifier?.type === "containingScope"
+    ? update(target, {
+        modifier: {
+          scopeType: (scopeType: string) =>
+            scopeTypeAliasToCanonicalName[scopeType] ?? scopeType,
+        },
+      })
+    : target;
+
+const canonicalizeColors = (
+  target: PartialPrimitiveTarget
+): PartialPrimitiveTarget =>
+  target.mark?.type === "decoratedSymbol"
+    ? update(target, {
+        mark: {
+          symbolColor: (symbolColor: string) =>
+            colorAliasToCanonicalName[symbolColor] ?? symbolColor,
+        },
+      })
+    : target;
+
 export default function canonicalizeTargets(partialTargets: PartialTarget[]) {
-  return transformPrimitiveTargets(partialTargets, (target) =>
-    target.modifier?.type === "containingScope"
-      ? update(target, {
-          modifier: {
-            scopeType: (scopeType) =>
-              scopeTypeAliasToCanonicalName[scopeType] ?? scopeType,
-          },
-        })
-      : target
+  return transformPrimitiveTargets(
+    partialTargets,
+    flow(canonicalizeScopeTypes, canonicalizeColors)
   );
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -7,8 +7,8 @@ export const HAT_COLORS = [
   "blue",
   "green",
   "red",
+  "pink",
   "yellow",
-  "purple",
 ] as const;
 
 export const HAT_NON_DEFAULT_SHAPES = [


### PR DESCRIPTION
"pink" will become the default term for this color in the next few weeks (see https://github.com/pokey/cursorless-talon/issues/66), and we will change the default color to be more obviously pink.  Hoping to reduce cognitive dissonance for colors

See also https://github.com/pokey/cursorless-talon/pull/75