### PR TITLE
Put identifier before repeatable symbols

### DIFF
--- a/src/core/tokenizer.ts
+++ b/src/core/tokenizer.ts
@@ -42,9 +42,9 @@ const NUMBERS_REGEX = "(?<=[^.\\d]|^)\\d+\\.\\d+(?=[^.\\d]|$)"; // (not-dot/digi
 
 const REGEX = [
   FIXED_TOKENS_REGEX,
-  REPEATABLE_SYMBOLS_REGEX,
   NUMBERS_REGEX,
   IDENTIFIERS_REGEX,
+  REPEATABLE_SYMBOLS_REGEX,
   SINGLE_SYMBOLS_REGEX,
 ].join("|");
 

--- a/src/test/suite/tokenizer.test.ts
+++ b/src/test/suite/tokenizer.test.ts
@@ -22,6 +22,7 @@ const tests: TestCase[] = [
   ["my.variable", ["my", ".", "variable"]],
   ["my/variable", ["my", "/", "variable"]],
   ["my::variable", ["my", "::", "variable"]],
+  ["_a", ["_a"]],
   // Strings
   ['"my variable"', ['"', "my", "variable", '"']],
   ["'my variable'", ["'", "my", "variable", "'"]],


### PR DESCRIPTION
Since repeatable symbols was before identifier `_a` was split into two tokens