### PR TITLE
Support value for return value

### DIFF
--- a/src/languages/python.ts
+++ b/src/languages/python.ts
@@ -4,6 +4,8 @@ import {
   argumentMatcher,
   prefixedMatcher,
   suffixedMatcher,
+  cascadingMatcher,
+  patternMatcher,
 } from "../util/nodeMatchers";
 import { NodeMatcherAlternative, ScopeType } from "../typings/Types";
 
@@ -64,7 +66,10 @@ const nodeMatchers: Partial<Record<ScopeType, NodeMatcherAlternative>> = {
     "*[name]",
   ],
   collectionItem: argumentMatcher(...dictionaryTypes, ...listTypes),
-  value: prefixedMatcher("assignment[right]", "~subscript[value]"),
+  value: cascadingMatcher(
+    prefixedMatcher("assignment[right]", "~subscript[value]"),
+    patternMatcher("return_statement.~return!")
+  ),
   argumentOrParameter: argumentMatcher("parameters", "argument_list"),
 };
 

--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -92,7 +92,10 @@ const nodeMatchers: Partial<Record<ScopeType, NodeMatcherAlternative>> = {
     "jsx_attribute.property_identifier!"
   ),
   collectionItem: argumentMatcher(...mapTypes, ...listTypes),
-  value: valueMatcher(),
+  value: cascadingMatcher(
+    valueMatcher(),
+    patternMatcher("return_statement.~return!")
+  ),
   ifStatement: "if_statement",
   anonymousFunction: ["arrow_function", "function"],
   name: [

--- a/src/test/suite/fixtures/recorded/languages/python/chuckValue2.yml
+++ b/src/test/suite/fixtures/recorded/languages/python/chuckValue2.yml
@@ -1,0 +1,27 @@
+spokenForm: chuck value
+languageId: python
+command:
+  actionName: remove
+  partialTargets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: value, includeSiblings: false}
+  extraArgs: []
+marks: {}
+initialState:
+  documentContents: |-
+    def foo():
+        return "hello"
+  selections:
+    - anchor: {line: 1, character: 14}
+      active: {line: 1, character: 14}
+finalState:
+  documentContents: |-
+    def foo():
+        return
+  selections:
+    - anchor: {line: 1, character: 10}
+      active: {line: 1, character: 10}
+  thatMark:
+    - anchor: {line: 1, character: 10}
+      active: {line: 1, character: 10}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: containingScope, scopeType: value, includeSiblings: false}}]

--- a/src/test/suite/fixtures/recorded/languages/python/clearValue.yml
+++ b/src/test/suite/fixtures/recorded/languages/python/clearValue.yml
@@ -1,0 +1,27 @@
+spokenForm: clear value
+languageId: python
+command:
+  actionName: clearAndSetSelection
+  partialTargets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: value, includeSiblings: false}
+  extraArgs: []
+marks: {}
+initialState:
+  documentContents: |-
+    def foo():
+        return "hello"
+  selections:
+    - anchor: {line: 1, character: 14}
+      active: {line: 1, character: 14}
+finalState:
+  documentContents: |-
+    def foo():
+        return 
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+  thatMark:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: value, includeSiblings: false}}]

--- a/src/test/suite/fixtures/recorded/languages/python/clearValue2.yml
+++ b/src/test/suite/fixtures/recorded/languages/python/clearValue2.yml
@@ -1,0 +1,27 @@
+spokenForm: clear value
+languageId: python
+command:
+  actionName: clearAndSetSelection
+  partialTargets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: value, includeSiblings: false}
+  extraArgs: []
+marks: {}
+initialState:
+  documentContents: |-
+    def foo():
+        return "hello"
+  selections:
+    - anchor: {line: 1, character: 7}
+      active: {line: 1, character: 7}
+finalState:
+  documentContents: |-
+    def foo():
+        return 
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+  thatMark:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 11}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: value, includeSiblings: false}}]

--- a/src/test/suite/fixtures/recorded/languages/typescript/takeValue3.yml
+++ b/src/test/suite/fixtures/recorded/languages/typescript/takeValue3.yml
@@ -1,0 +1,29 @@
+spokenForm: take value
+languageId: typescript
+command:
+  actionName: setSelection
+  partialTargets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: value, includeSiblings: false}
+  extraArgs: []
+marks: {}
+initialState:
+  documentContents: |-
+    function foo() {
+        return "hello";
+    }
+  selections:
+    - anchor: {line: 1, character: 14}
+      active: {line: 1, character: 14}
+finalState:
+  documentContents: |-
+    function foo() {
+        return "hello";
+    }
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 18}
+  thatMark:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 18}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: value, includeSiblings: false}}]

--- a/src/test/suite/fixtures/recorded/languages/typescript/takeValue4.yml
+++ b/src/test/suite/fixtures/recorded/languages/typescript/takeValue4.yml
@@ -1,0 +1,29 @@
+spokenForm: take value
+languageId: typescript
+command:
+  actionName: setSelection
+  partialTargets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: value, includeSiblings: false}
+  extraArgs: []
+marks: {}
+initialState:
+  documentContents: |-
+    function foo() {
+        return "hello";
+    }
+  selections:
+    - anchor: {line: 1, character: 7}
+      active: {line: 1, character: 7}
+finalState:
+  documentContents: |-
+    function foo() {
+        return "hello";
+    }
+  selections:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 18}
+  thatMark:
+    - anchor: {line: 1, character: 11}
+      active: {line: 1, character: 18}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: value, includeSiblings: false}}]


### PR DESCRIPTION
This has a couple known issues in typescript:

1. It will select the semicolon if your cursor is right before it
2. It will not remove the leading space if you say "chuck value"

I think worth merging because it is an improvement.  Can file the others for later