### PR TITLE
Stop using end of range as inference source

### DIFF
--- a/src/core/inferFullTargets.ts
+++ b/src/core/inferFullTargets.ts
@@ -102,7 +102,9 @@ function inferPrimitiveTarget(
     getPreviousAttribute(previousTargetsForAttributes, "selectionType");
 
   const mark = target.mark ??
-    (isPositionalTarget(target) ? getPreviousMark(previousTargets) : null) ?? {
+    (target.position === "before" || target.position === "after"
+      ? getPreviousMark(previousTargets)
+      : null) ?? {
       type: maybeSelectionType === "token" ? "cursorToken" : "cursor",
     };
 
@@ -135,18 +137,6 @@ function inferPrimitiveTarget(
   };
 }
 
-/**
- * Checks if the target doesn't refer to contents, but instead to a position
- * such as before or after.  We avoid using such targets for inference in
- * certain cases.
- *
- * @param target The target to check
- * @returns Wether it is not a content target
- */
-function isPositionalTarget(target: PartialPrimitiveTarget) {
-  return target.position === "before" || target.position === "after";
-}
-
 function getPreviousMark(previousTargets: PartialTarget[]) {
   return getPreviousAttribute(
     previousTargets,
@@ -163,14 +153,10 @@ function getPreviousPosition(previousTargets: PartialTarget[]) {
   );
 }
 
-function defaultUseTarget(target: PartialPrimitiveTarget) {
-  return hasContent(target) && !isPositionalTarget(target);
-}
-
 function getPreviousAttribute<T extends keyof PartialPrimitiveTarget>(
   previousTargets: PartialTarget[],
   attributeName: T,
-  useTarget: (target: PartialPrimitiveTarget) => boolean = defaultUseTarget
+  useTarget: (target: PartialPrimitiveTarget) => boolean = hasContent
 ) {
   const target = getPreviousTarget(previousTargets, useTarget);
   return target != null ? target[attributeName] : null;
@@ -190,9 +176,6 @@ function getPreviousTarget(
         }
         break;
       case "range":
-        if (useTarget(target.end)) {
-          return target.end;
-        }
         if (useTarget(target.start)) {
           return target.start;
         }

--- a/src/test/suite/fixtures/recorded/inference/bringLineBatPastEndOfFunkToThis.yml
+++ b/src/test/suite/fixtures/recorded/inference/bringLineBatPastEndOfFunkToThis.yml
@@ -1,0 +1,58 @@
+spokenForm: bring line bat past end of funk to this
+languageId: typescript
+command:
+  actionName: replaceWithTarget
+  partialTargets:
+    - type: range
+      start:
+        type: primitive
+        selectionType: line
+        mark: {type: decoratedSymbol, symbolColor: default, character: b}
+      end:
+        type: primitive
+        position: after
+        insideOutsideType: inside
+        modifier: {type: containingScope, scopeType: namedFunction, includeSiblings: false}
+      excludeStart: false
+      excludeEnd: false
+    - type: primitive
+      mark: {type: cursor}
+  extraArgs: []
+marks:
+  default.b:
+    start: {line: 1, character: 8}
+    end: {line: 1, character: 11}
+initialState:
+  documentContents: |
+    function foo() {
+      const bar = "hello";
+
+      const baz = "hi";
+    }
+
+    const bongo = "bazman";
+  selections:
+    - anchor: {line: 6, character: 20}
+      active: {line: 6, character: 20}
+finalState:
+  documentContents: |
+    function foo() {
+      const bar = "hello";
+
+      const baz = "hi";
+    }
+
+    const bar = "hello";
+
+      const baz = "hi";
+    }
+  selections:
+    - anchor: {line: 6, character: 20}
+      active: {line: 6, character: 20}
+  thatMark:
+    - anchor: {line: 6, character: 0}
+      active: {line: 9, character: 1}
+  sourceMark:
+    - anchor: {line: 1, character: 2}
+      active: {line: 4, character: 1}
+fullTargets: [{type: range, excludeAnchor: false, excludeActive: false, anchor: {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}}, active: {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: b}, selectionType: token, position: after, insideOutsideType: inside, modifier: {type: containingScope, scopeType: namedFunction, includeSiblings: false}}}, {type: primitive, mark: {type: cursor}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}}]


### PR DESCRIPTION
Forgot to fix the checkbox in #283: change it so that "bring line air past end of funk to this" refers to "this line" rather than "this funk"