### PR TITLE
Re enabled warning outside of viewport edit

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
 		"url": "https://github.com/pokey/cursorless-vscode.git"
 	},
 	"engines": {
-		"vscode": "^1.53.0"
+		"vscode": "^1.58.0"
 	},
 	"extensionKind": [
 		"workspace"
@@ -440,7 +440,7 @@
 		"@types/mocha": "^8.0.4",
 		"@types/node": "^16.11.3",
 		"@types/sinon": "^10.0.2",
-		"@types/vscode": "^1.53.0",
+		"@types/vscode": "1.58.0",
 		"@typescript-eslint/eslint-plugin": "^4.9.0",
 		"@typescript-eslint/parser": "^4.9.0",
 		"esbuild": "^0.11.12",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -204,6 +204,10 @@ export async function activate(context: vscode.ExtensionContext) {
   addDecorationsDebounced();
 
   function checkForEditsOutsideViewport(event: vscode.TextDocumentChangeEvent) {
+    // Bail if reason is undo or redo. undefined = normal edit
+    if (event.reason) {
+      return;
+    }
     const editor = vscode.window.activeTextEditor;
     if (editor == null || editor.document !== event.document) {
       return;
@@ -233,9 +237,7 @@ export async function activate(context: vscode.ExtensionContext) {
   function handleEdit(edit: vscode.TextDocumentChangeEvent) {
     addDecorationsDebounced();
 
-    // TODO. Disabled for now because it triggers on undo as well
-    //  wait until next release when there is a cause field
-    // checkForEditsOutsideViewport(edit);
+    checkForEditsOutsideViewport(edit);
   }
 
   const recomputeDecorationStyles = async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,10 +143,10 @@
   dependencies:
     "@sinonjs/fake-timers" "^7.1.0"
 
-"@types/vscode@^1.53.0":
-  version "1.53.0"
-  resolved "https://registry.npmjs.org/@types/vscode/-/vscode-1.53.0.tgz"
-  integrity sha512-XjFWbSPOM0EKIT2XhhYm3D3cx3nn3lshMUcWNy1eqefk+oqRuBq8unVb6BYIZqXy9lQZyeUl7eaBCOZWv+LcXQ==
+"@types/vscode@1.58.0":
+  version "1.58.0"
+  resolved "https://registry.yarnpkg.com/@types/vscode/-/vscode-1.58.0.tgz#91662aa27197c750df314e0d27de4b23512ebe59"
+  integrity sha512-enznxcBi4uYt20LWal09E0+VKEHZlq9PZawTu/mpWCVCFWWbiyR8HNI1ikBP1Ypqv8b3A/0md3DY1jcx+oQ8kQ==
 
 "@typescript-eslint/eslint-plugin@^4.9.0":
   version "4.15.0"


### PR DESCRIPTION
Warning is enabled on undo and redo. Only initial/normal edit outside of viewport will trigger the warning.

fixes #45 

I'm unsure if this is a good solution. The are no hats outside of the viewport. I'm leaning to just restrict line commands to viewport and then be happy. Implementation in this pr could be useful in the future if we for some reason add a command that can edit outside of the viewport.

