### PR TITLE
Updated leading and trailing delimiters for before and after positions

### DIFF
--- a/src/processTargets/processSelectionType.ts
+++ b/src/processTargets/processSelectionType.ts
@@ -213,10 +213,16 @@ function getTokenSelectionContext(
         : null;
   }
 
-  const isInDelimitedList =
-    (leadingDelimiterRange != null || trailingDelimiterRange != null) &&
-    (leadingDelimiterRange != null || start.character === 0) &&
-    (trailingDelimiterRange != null || end.isEqual(endLine.range.end));
+  let isInDelimitedList;
+  if (position === "contents") {
+    isInDelimitedList =
+      (leadingDelimiterRange != null || trailingDelimiterRange != null) &&
+      (leadingDelimiterRange != null || start.character === 0) &&
+      (trailingDelimiterRange != null || end.isEqual(endLine.range.end));
+  } else {
+    isInDelimitedList =
+      leadingDelimiterRange != null || trailingDelimiterRange != null;
+  }
 
   return {
     isInDelimitedList,

--- a/src/test/suite/fixtures/recorded/positions/chuckAfterHarp.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckAfterHarp.yml
@@ -1,0 +1,35 @@
+spokenForm: chuck after harp
+languageId: typescript
+command:
+  actionName: remove
+  partialTargets:
+    - type: primitive
+      position: after
+      mark: {type: decoratedSymbol, symbolColor: default, character: h}
+  extraArgs: []
+initialState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.h:
+      start: {line: 2, character: 2}
+      end: {line: 2, character: 7}
+finalState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello"
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  thatMark:
+    - anchor: {line: 2, character: 7}
+      active: {line: 2, character: 7}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: after, insideOutsideType: outside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/positions/chuckAfterLook.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckAfterLook.yml
@@ -1,0 +1,35 @@
+spokenForm: chuck after look
+languageId: typescript
+command:
+  actionName: remove
+  partialTargets:
+    - type: primitive
+      position: after
+      mark: {type: decoratedSymbol, symbolColor: default, character: l}
+  extraArgs: []
+initialState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.l:
+      start: {line: 0, character: 1}
+      end: {line: 0, character: 6}
+finalState:
+  documentContents: |
+    "hello"
+    " hello"
+    " hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  thatMark:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: l}, selectionType: token, position: after, insideOutsideType: outside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/positions/chuckAir.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckAir.yml
@@ -1,0 +1,34 @@
+spokenForm: chuck air
+languageId: typescript
+command:
+  actionName: remove
+  partialTargets:
+    - type: primitive
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  extraArgs: []
+initialState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.a:
+      start: {line: 3, character: 7}
+      end: {line: 3, character: 8}
+finalState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello "
+    return .b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  thatMark:
+    - anchor: {line: 3, character: 7}
+      active: {line: 3, character: 7}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: outside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/positions/chuckBeforeAir.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckBeforeAir.yml
@@ -1,0 +1,35 @@
+spokenForm: chuck before air
+languageId: typescript
+command:
+  actionName: remove
+  partialTargets:
+    - type: primitive
+      position: before
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+  extraArgs: []
+initialState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.a:
+      start: {line: 3, character: 7}
+      end: {line: 3, character: 8}
+finalState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello "
+    returna.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  thatMark:
+    - anchor: {line: 3, character: 6}
+      active: {line: 3, character: 6}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: before, insideOutsideType: outside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/positions/chuckBeforeEach.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckBeforeEach.yml
@@ -1,0 +1,35 @@
+spokenForm: chuck before each
+languageId: typescript
+command:
+  actionName: remove
+  partialTargets:
+    - type: primitive
+      position: before
+      mark: {type: decoratedSymbol, symbolColor: default, character: e}
+  extraArgs: []
+initialState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.e:
+      start: {line: 1, character: 2}
+      end: {line: 1, character: 7}
+finalState:
+  documentContents: |
+    "hello "
+    "hello"
+    " hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 1}
+      active: {line: 1, character: 1}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: e}, selectionType: token, position: before, insideOutsideType: outside, modifier: {type: identity}}]

--- a/src/test/suite/fixtures/recorded/positions/chuckBeforeHarp.yml
+++ b/src/test/suite/fixtures/recorded/positions/chuckBeforeHarp.yml
@@ -1,0 +1,35 @@
+spokenForm: chuck before harp
+languageId: typescript
+command:
+  actionName: remove
+  partialTargets:
+    - type: primitive
+      position: before
+      mark: {type: decoratedSymbol, symbolColor: default, character: h}
+  extraArgs: []
+initialState:
+  documentContents: |
+    "hello "
+    " hello"
+    " hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.h:
+      start: {line: 2, character: 2}
+      end: {line: 2, character: 7}
+finalState:
+  documentContents: |
+    "hello "
+    " hello"
+    "hello "
+    return a.b
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  thatMark:
+    - anchor: {line: 2, character: 1}
+      active: {line: 2, character: 1}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: before, insideOutsideType: outside, modifier: {type: identity}}]


### PR DESCRIPTION
Delimiter was not aggressive enough for positions before/after. Many times `chuck before token` would fail. 
Updated delimiter code and added additional tests.