### PR TITLE
Add wrapper to avoid multiple done calls

### DIFF
--- a/src/test/suite/asyncSafety.ts
+++ b/src/test/suite/asyncSafety.ts
@@ -1,0 +1,34 @@
+import { AsyncFunc, Context, Done } from "mocha";
+
+/**
+ * if an async returns after the method times out,
+ * it will cause a "done() called multiple times" error.
+ * In the context of a running webdriver, this is potentially very bad.
+ * We need to be able to quit the driver gracefully under any circumstances.
+ * This allows methods to time out while an async is pending,
+ * and will avoid calling done twice in this case.
+ *
+ * From https://github.com/mochajs/mocha/issues/967#issuecomment-810484206
+ * @param fn The test function to run
+ * @returns A safely wrapped test function
+ */
+export default function asyncSafety(fn: AsyncFunc) {
+  return function (this: Context, done: Done) {
+    let runnable = this.runnable();
+
+    fn.bind(this)()
+      .then((res) => {
+        // for successful I think we only need timedOut? not sure though, might have side effects
+        // when the duration check is added it will get stuck and never complete on a second runthrough
+        if (!runnable.timedOut) {
+          done(res);
+        }
+      })
+      // @ts-ignore
+      .catch((err) => {
+        if (!runnable.timedOut && !runnable.duration) {
+          done(err);
+        }
+      });
+  };
+}

--- a/src/test/suite/recorded.test.ts
+++ b/src/test/suite/recorded.test.ts
@@ -24,6 +24,7 @@ import {
 } from "../../util/getExtensionApi";
 import { enableDebugLog } from "../../util/debug";
 import { extractTargetedMarks } from "../../testUtil/extractTargetedMarks";
+import asyncSafety from "./asyncSafety";
 
 function createPosition(position: PositionPlainObject) {
   return new vscode.Position(position.line, position.character);
@@ -49,7 +50,12 @@ suite("recorded test cases", async function () {
     sinon.restore();
   });
 
-  files.forEach((file) => test(file.split(".")[0], () => runTest(file)));
+  files.forEach((file) =>
+    test(
+      file.split(".")[0],
+      asyncSafety(() => runTest(file))
+    )
+  );
 });
 
 async function runTest(file: string) {


### PR DESCRIPTION
Fixes nondeterministic test failure seen locally