### PR TITLE
Implemented strict here selection type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,9 +12,10 @@
     // Turn off tsc task auto detection since we have the necessary tasks as npm scripts
     "typescript.tsc.autoDetect": "off",
     "cSpell.words": [
-        "subword",
+        "Autoformatting",
         "eqeqeq",
         "nonlocal",
-        "pojo"
+        "pojo",
+        "subword"
     ]
 }

--- a/src/actions/BringMoveSwap.ts
+++ b/src/actions/BringMoveSwap.ts
@@ -115,8 +115,12 @@ class BringMoveSwap implements Action {
               let text = source.selection.editor.document.getText(
                 source.selection.selection
               );
-              return i > 0 && destination.selectionContext.containingListDelimiter
-                ? destination.selectionContext.containingListDelimiter + text
+              const selectionContext =
+                destination.selectionType === "strictHere"
+                  ? source.selectionContext
+                  : destination.selectionContext;
+              return i > 0 && selectionContext.containingListDelimiter
+                ? selectionContext.containingListDelimiter + text
                 : text;
             })
             .join("");

--- a/src/actions/BringMoveSwap.ts
+++ b/src/actions/BringMoveSwap.ts
@@ -115,10 +115,10 @@ class BringMoveSwap implements Action {
               let text = source.selection.editor.document.getText(
                 source.selection.selection
               );
-              const selectionContext =
-                destination.selectionType === "strictHere"
-                  ? source.selectionContext
-                  : destination.selectionContext;
+              const selectionContext = destination.selectionContext
+                .isRawSelection
+                ? source.selectionContext
+                : destination.selectionContext;
               return i > 0 && selectionContext.containingListDelimiter
                 ? selectionContext.containingListDelimiter + text
                 : text;

--- a/src/core/inferFullTargets.ts
+++ b/src/core/inferFullTargets.ts
@@ -94,9 +94,11 @@ function inferPrimitiveTarget(
   previousTargets: PartialTarget[],
   actionPreferences: ActionPreferences
 ): PrimitiveTarget {
-  const previousTargetsForAttributes = hasContent(target)
-    ? []
-    : previousTargets;
+  const doAttributeInference = !hasContent(target) && !target.isImplicit;
+
+  const previousTargetsForAttributes = doAttributeInference
+    ? previousTargets
+    : [];
 
   const maybeSelectionType =
     target.selectionType ??
@@ -117,7 +119,7 @@ function inferPrimitiveTarget(
 
   const selectionType =
     maybeSelectionType ??
-    (target.modifier == null ? actionPreferences.selectionType : null) ??
+    (doAttributeInference ? actionPreferences.selectionType : null) ??
     "token";
 
   const insideOutsideType =
@@ -127,7 +129,7 @@ function inferPrimitiveTarget(
 
   const modifier = target.modifier ??
     getPreviousAttribute(previousTargetsForAttributes, "modifier") ??
-    (target.selectionType == null ? actionPreferences.modifier : null) ?? {
+    (doAttributeInference ? actionPreferences.modifier : null) ?? {
       type: "identity",
     };
 
@@ -138,6 +140,7 @@ function inferPrimitiveTarget(
     position,
     insideOutsideType,
     modifier,
+    isImplicit: target.isImplicit ?? false,
   };
 }
 

--- a/src/processTargets/index.ts
+++ b/src/processTargets/index.ts
@@ -12,7 +12,6 @@ import processMark from "./processMark";
 import processModifier from "./modifiers/processModifier";
 import processPosition from "./processPosition";
 import processSelectionType from "./processSelectionType";
-import { isForward as getIsForward } from "../util/selectionUtils";
 
 export default function (
   context: ProcessedTargetsContext,

--- a/src/processTargets/index.ts
+++ b/src/processTargets/index.ts
@@ -274,6 +274,13 @@ function processPrimitiveTarget(
     ({ selection, context: selectionContext }) =>
       processSelectionType(context, target, selection, selectionContext)
   );
+
+  if (target.isImplicit) {
+    typedSelections.forEach((typedSelection) => {
+      typedSelection.selectionContext.isRawSelection = true;
+    });
+  }
+
   return typedSelections.map((selection) =>
     processPosition(context, target, selection)
   );

--- a/src/processTargets/modifiers/processModifier.ts
+++ b/src/processTargets/modifiers/processModifier.ts
@@ -10,6 +10,7 @@ import {
   NodeMatcher,
   PrimitiveTarget,
   ProcessedTargetsContext,
+  RawSelectionModifier,
   SelectionContext,
   SelectionWithEditor,
   SubTokenModifier,
@@ -52,6 +53,14 @@ export default function (
     case "surroundingPair":
       result = processSurroundingPair(context, selection, modifier);
       break;
+
+    case "toRawSelection":
+      result = processRawSelectionModifier(context, selection, modifier);
+      break;
+
+    default:
+      // Make sure we haven't missed any cases
+      const neverCheck: never = modifier;
   }
 
   if (result == null) {
@@ -232,4 +241,17 @@ export function findNearestContainingAncestorNode(
   }
 
   return null;
+}
+
+function processRawSelectionModifier(
+  context: ProcessedTargetsContext,
+  selection: SelectionWithEditor,
+  modifier: RawSelectionModifier
+): SelectionWithEditorWithContext[] | null {
+  return [
+    {
+      selection,
+      context: { isRawSelection: true },
+    },
+  ];
 }

--- a/src/processTargets/processSelectionType.ts
+++ b/src/processTargets/processSelectionType.ts
@@ -51,21 +51,6 @@ function processNotebookCell(
   };
 }
 
-function processStrictHere(
-  target: PrimitiveTarget,
-  selection: SelectionWithEditor,
-  selectionContext: SelectionContext
-): TypedSelection {
-  const { selectionType, insideOutsideType, position } = target;
-  return {
-    selection,
-    selectionType,
-    position,
-    insideOutsideType,
-    selectionContext,
-  };
-}
-
 function processToken(
   target: PrimitiveTarget,
   selection: SelectionWithEditor,

--- a/src/processTargets/processSelectionType.ts
+++ b/src/processTargets/processSelectionType.ts
@@ -33,6 +33,8 @@ export default function (
       return processLine(target, selection, selectionContext);
     case "paragraph":
       return processParagraph(target, selection, selectionContext);
+    case "strictHere":
+      return processStrictHere(target, selection, selectionContext);
   }
 }
 
@@ -48,6 +50,21 @@ function processNotebookCell(
     position,
     insideOutsideType,
     selectionContext: { ...selectionContext, isNotebookCell: true },
+  };
+}
+
+function processStrictHere(
+  target: PrimitiveTarget,
+  selection: SelectionWithEditor,
+  selectionContext: SelectionContext
+): TypedSelection {
+  const { selectionType, insideOutsideType, position } = target;
+  return {
+    selection,
+    selectionType,
+    position,
+    insideOutsideType,
+    selectionContext,
   };
 }
 

--- a/src/processTargets/processSelectionType.ts
+++ b/src/processTargets/processSelectionType.ts
@@ -77,13 +77,22 @@ function processToken(
     selectionType,
     position,
     insideOutsideType,
-    selectionContext: getTokenSelectionContext(
-      selection,
-      modifier,
-      position,
-      insideOutsideType,
-      selectionContext
-    ),
+    // NB: This is a hack to work around the fact that it's not currently
+    // possible to apply a modifier after processing the selection type. We
+    // would really prefer that the user be able to say "just" and have that be
+    // processed after we've processed the selection type, which would strip
+    // away the type information and turn it into a raw target. Until that's
+    // possible using the new pipelines, we instead just check for it here when
+    // we're doing the selection type and bail out if it is a raw target.
+    selectionContext: selectionContext.isRawSelection
+      ? selectionContext
+      : getTokenSelectionContext(
+          selection,
+          modifier,
+          position,
+          insideOutsideType,
+          selectionContext
+        ),
   };
 }
 

--- a/src/processTargets/processSelectionType.ts
+++ b/src/processTargets/processSelectionType.ts
@@ -33,8 +33,6 @@ export default function (
       return processLine(target, selection, selectionContext);
     case "paragraph":
       return processParagraph(target, selection, selectionContext);
-    case "strictHere":
-      return processStrictHere(target, selection, selectionContext);
   }
 }
 

--- a/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCap.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringAirAndBatAndCap.yml
@@ -12,12 +12,7 @@ command:
           mark: {type: decoratedSymbol, symbolColor: default, character: b}
         - type: primitive
           mark: {type: decoratedSymbol, symbolColor: default, character: c}
-    - type: primitive
-      mark: {type: cursor}
-      selectionType: token
-      position: contents
-      modifier: {type: identity}
-      insideOutsideType: inside
+    - {type: primitive, isImplicit: true}
 initialState:
   documentContents: |+
     a

--- a/src/test/suite/fixtures/recorded/actions/bringArgueFineAndZip.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringArgueFineAndZip.yml
@@ -1,0 +1,54 @@
+languageId: typescript
+command:
+  version: 1
+  spokenForm: bring argue fine and zip
+  action: replaceWithTarget
+  targets:
+    - type: list
+      elements:
+        - type: primitive
+          modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}
+          mark: {type: decoratedSymbol, symbolColor: default, character: f}
+        - type: primitive
+          mark: {type: decoratedSymbol, symbolColor: default, character: z}
+    - {type: primitive, isImplicit: true}
+initialState:
+  documentContents: |-
+    function helloWorld(foo: string, bar: number, baz: string) {
+
+    }
+
+    function bongo() {
+        
+    }
+  selections:
+    - anchor: {line: 4, character: 15}
+      active: {line: 4, character: 15}
+  marks:
+    default.f:
+      start: {line: 0, character: 20}
+      end: {line: 0, character: 23}
+    default.z:
+      start: {line: 0, character: 46}
+      end: {line: 0, character: 49}
+finalState:
+  documentContents: |-
+    function helloWorld(foo: string, bar: number, baz: string) {
+
+    }
+
+    function bongo(foo: string, baz: string) {
+        
+    }
+  selections:
+    - anchor: {line: 4, character: 39}
+      active: {line: 4, character: 39}
+  thatMark:
+    - anchor: {line: 4, character: 15}
+      active: {line: 4, character: 39}
+  sourceMark:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 31}
+    - anchor: {line: 0, character: 46}
+      active: {line: 0, character: 57}
+fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: f}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: z}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}]}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: true}]

--- a/src/test/suite/fixtures/recorded/actions/bringArgueOxAndZipToAfterJustLeper.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringArgueOxAndZipToAfterJustLeper.yml
@@ -1,0 +1,60 @@
+languageId: typescript
+command:
+  version: 1
+  spokenForm: bring argue ox and zip to after just leper
+  action: replaceWithTarget
+  targets:
+    - type: list
+      elements:
+        - type: primitive
+          modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}
+          mark: {type: decoratedSymbol, symbolColor: default, character: o}
+        - type: primitive
+          mark: {type: decoratedSymbol, symbolColor: default, character: z}
+    - type: primitive
+      position: after
+      modifier: {type: toRawSelection}
+      mark: {type: decoratedSymbol, symbolColor: default, character: (}
+initialState:
+  documentContents: |-
+    function helloWorld(foo: string, bar: number, baz: string) {
+
+    }
+
+    function bongo() {
+        
+    }
+  selections:
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+  marks:
+    default.o:
+      start: {line: 0, character: 20}
+      end: {line: 0, character: 23}
+    default.z:
+      start: {line: 0, character: 46}
+      end: {line: 0, character: 49}
+    default.(:
+      start: {line: 4, character: 14}
+      end: {line: 4, character: 15}
+finalState:
+  documentContents: |-
+    function helloWorld(foo: string, bar: number, baz: string) {
+
+    }
+
+    function bongo(foo: string, baz: string) {
+        
+    }
+  selections:
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+  thatMark:
+    - anchor: {line: 4, character: 15}
+      active: {line: 4, character: 39}
+  sourceMark:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 31}
+    - anchor: {line: 0, character: 46}
+      active: {line: 0, character: 57}
+fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: o}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: z}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: containingScope, scopeType: argumentOrParameter, includeSiblings: false}, isImplicit: false}]}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: (}, selectionType: token, position: after, insideOutsideType: null, modifier: {type: toRawSelection}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/actions/bringLineHarpAndWhale.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringLineHarpAndWhale.yml
@@ -1,0 +1,50 @@
+languageId: plaintext
+command:
+  version: 1
+  spokenForm: bring line harp and whale
+  action: replaceWithTarget
+  targets:
+    - type: list
+      elements:
+        - type: primitive
+          selectionType: line
+          mark: {type: decoratedSymbol, symbolColor: default, character: h}
+        - type: primitive
+          mark: {type: decoratedSymbol, symbolColor: default, character: w}
+    - {type: primitive, isImplicit: true}
+initialState:
+  documentContents: |+
+    hello
+    there
+    whatever
+
+  selections:
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}
+  marks:
+    default.h:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 5}
+    default.w:
+      start: {line: 2, character: 0}
+      end: {line: 2, character: 8}
+finalState:
+  documentContents: |-
+    hello
+    there
+    whatever
+
+    hello
+    whatever
+  selections:
+    - anchor: {line: 5, character: 8}
+      active: {line: 5, character: 8}
+  thatMark:
+    - anchor: {line: 4, character: 0}
+      active: {line: 5, character: 8}
+  sourceMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 5}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 8}
+fullTargets: [{type: list, elements: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: w}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: false}]}, {type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: true}]

--- a/src/test/suite/fixtures/recorded/actions/bringVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/bringVest.yml
@@ -6,12 +6,7 @@ command:
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: v}
-    - type: primitive
-      mark: {type: cursor}
-      selectionType: token
-      position: contents
-      modifier: {type: identity}
-      insideOutsideType: inside
+    - {type: primitive, isImplicit: true}
 initialState:
   documentContents: |
 

--- a/src/test/suite/fixtures/recorded/actions/callFine.yml
+++ b/src/test/suite/fixtures/recorded/actions/callFine.yml
@@ -6,12 +6,7 @@ command:
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: f}
-    - type: primitive
-      mark: {type: cursor}
-      selectionType: token
-      position: contents
-      modifier: {type: identity}
-      insideOutsideType: inside
+    - {type: primitive, isImplicit: true}
 initialState:
   documentContents: |-
     foo;

--- a/src/test/suite/fixtures/recorded/actions/callVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/callVest.yml
@@ -6,12 +6,7 @@ command:
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: v}
-    - type: primitive
-      mark: {type: cursor}
-      selectionType: token
-      position: contents
-      modifier: {type: identity}
-      insideOutsideType: inside
+    - {type: primitive, isImplicit: true}
 initialState:
   documentContents: |
 

--- a/src/test/suite/fixtures/recorded/actions/moveVest.yml
+++ b/src/test/suite/fixtures/recorded/actions/moveVest.yml
@@ -6,12 +6,7 @@ command:
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: v}
-    - type: primitive
-      mark: {type: cursor}
-      selectionType: token
-      position: contents
-      modifier: {type: identity}
-      insideOutsideType: inside
+    - {type: primitive, isImplicit: true}
 initialState:
   documentContents: |
 

--- a/src/test/suite/fixtures/recorded/hatTokenMap/bringHarpTakeWhale.yml
+++ b/src/test/suite/fixtures/recorded/hatTokenMap/bringHarpTakeWhale.yml
@@ -6,12 +6,7 @@ command:
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: h}
-    - type: primitive
-      mark: {type: cursor}
-      selectionType: token
-      position: contents
-      modifier: {type: identity}
-      insideOutsideType: inside
+    - {type: primitive, isImplicit: true}
 marksToCheck: [default.w]
 initialState:
   documentContents: hello world

--- a/src/test/suite/fixtures/recorded/inference/bringLineLookToJustAir.yml
+++ b/src/test/suite/fixtures/recorded/inference/bringLineLookToJustAir.yml
@@ -1,0 +1,40 @@
+languageId: plaintext
+command:
+  version: 1
+  spokenForm: bring line look to just air
+  action: replaceWithTarget
+  targets:
+    - type: primitive
+      selectionType: line
+      mark: {type: decoratedSymbol, symbolColor: default, character: l}
+    - type: primitive
+      modifier: {type: toRawSelection}
+      mark: {type: decoratedSymbol, symbolColor: default, character: a}
+initialState:
+  documentContents: |
+    hello there
+    whatever now
+  selections:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+  marks:
+    default.l:
+      start: {line: 0, character: 0}
+      end: {line: 0, character: 5}
+    default.a:
+      start: {line: 1, character: 0}
+      end: {line: 1, character: 8}
+finalState:
+  documentContents: |
+    hello there
+    hello there now
+  selections:
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+  thatMark:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 11}
+  sourceMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 11}
+fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: l}, selectionType: line, position: contents, insideOutsideType: null, modifier: {type: identity}, isImplicit: false}, {type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: a}, selectionType: token, position: contents, insideOutsideType: null, modifier: {type: toRawSelection}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/languages/typescript/clearType2.yml
+++ b/src/test/suite/fixtures/recorded/languages/typescript/clearType2.yml
@@ -1,6 +1,6 @@
 languageId: typescript
 command:
-  version: 0
+  version: 1
   spokenForm: clear type
   action: clearAndSetSelection
   targets:

--- a/src/test/suite/fixtures/recorded/updateSelections/bringFine.yml
+++ b/src/test/suite/fixtures/recorded/updateSelections/bringFine.yml
@@ -6,12 +6,7 @@ command:
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: f}
-    - type: primitive
-      mark: {type: cursor}
-      selectionType: token
-      position: contents
-      modifier: {type: identity}
-      insideOutsideType: inside
+    - {type: primitive, isImplicit: true}
 initialState:
   documentContents: foo world
   selections:

--- a/src/test/suite/fixtures/recorded/updateSelections/bringWhale.yml
+++ b/src/test/suite/fixtures/recorded/updateSelections/bringWhale.yml
@@ -6,12 +6,7 @@ command:
   targets:
     - type: primitive
       mark: {type: decoratedSymbol, symbolColor: default, character: w}
-    - type: primitive
-      mark: {type: cursor}
-      selectionType: token
-      position: contents
-      modifier: {type: identity}
-      insideOutsideType: inside
+    - {type: primitive, isImplicit: true}
 initialState:
   documentContents: foo world
   selections:

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -174,7 +174,13 @@ export type Modifier =
 
 export type SelectionType =
   //   | "character" Not implemented
-  "token" | "line" | "notebookCell" | "paragraph" | "document";
+  | "token"
+  | "line"
+  | "notebookCell"
+  | "paragraph"
+  | "document"
+  | "column"
+  | "strictHere";
 
 export type Position = "before" | "after" | "contents";
 

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -155,7 +155,12 @@ export interface IdentityModifier {
   type: "identity";
 }
 
-export interface ToRawSelectionModifier {
+/**
+ * Converts its input to a raw selection with no type information so for
+ * example if it is the destination of a bring or move it should inherit the
+ * type information such as delimiters from its source.
+ */
+export interface RawSelectionModifier {
   type: "toRawSelection";
 }
 
@@ -174,7 +179,8 @@ export type Modifier =
   | SubTokenModifier
   //   | MatchingPairSymbolModifier Not implemented
   | HeadModifier
-  | TailModifier;
+  | TailModifier
+  | RawSelectionModifier;
 
 export type SelectionType =
   //   | "character" Not implemented
@@ -297,6 +303,13 @@ export interface SelectionContext {
    * statement this would be the statements in the body.
    */
   interior?: SelectionWithContext[];
+
+  /**
+   * Indicates that this is a raw selection with no type information so for
+   * example if it is the destination of a bring or move it should inherit the
+   * type information such as delimiters from its source
+   */
+  isRawSelection?: boolean;
 }
 
 export interface TypedSelection {

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -155,6 +155,10 @@ export interface IdentityModifier {
   type: "identity";
 }
 
+export interface ToRawSelectionModifier {
+  type: "toRawSelection";
+}
+
 export interface HeadModifier {
   type: "head";
 }
@@ -193,6 +197,7 @@ export interface PartialPrimitiveTarget {
   selectionType?: SelectionType;
   position?: Position;
   insideOutsideType?: InsideOutsideType;
+  isImplicit?: boolean;
 }
 
 export interface PartialRangeTarget {
@@ -221,6 +226,7 @@ export interface PrimitiveTarget {
   selectionType: SelectionType;
   position: Position;
   insideOutsideType: InsideOutsideType;
+  isImplicit: boolean;
 }
 
 export interface RangeTarget {

--- a/src/typings/Types.ts
+++ b/src/typings/Types.ts
@@ -184,13 +184,7 @@ export type Modifier =
 
 export type SelectionType =
   //   | "character" Not implemented
-  | "token"
-  | "line"
-  | "notebookCell"
-  | "paragraph"
-  | "document"
-  | "column"
-  | "strictHere";
+  "token" | "line" | "notebookCell" | "paragraph" | "document";
 
 export type Position = "before" | "after" | "contents";
 

--- a/src/util/canonicalizeTargets.ts
+++ b/src/util/canonicalizeTargets.ts
@@ -7,6 +7,7 @@ import update from "immutability-helper";
 import { transformPartialPrimitiveTargets } from "./getPrimitiveTargets";
 import { HatStyleName } from "../core/constants";
 import { flow } from "lodash";
+import { isDeepStrictEqual } from "util";
 
 const SCOPE_TYPE_CANONICALIZATION_MAPPING: Record<string, ScopeType> = {
   arrowFunction: "anonymousFunction",
@@ -42,9 +43,27 @@ const canonicalizeColors = (
       })
     : target;
 
+const STRICT_HERE = {
+  type: "primitive",
+  mark: { type: "cursor" },
+  selectionType: "token",
+  position: "contents",
+  modifier: { type: "identity" },
+  insideOutsideType: "inside",
+};
+
+const upgradeStrictHere = (
+  target: PartialPrimitiveTarget
+): PartialPrimitiveTarget =>
+  isDeepStrictEqual(target, STRICT_HERE)
+    ? update(target, {
+        selectionType: () => "strictHere",
+      })
+    : target;
+
 export default function canonicalizeTargets(partialTargets: PartialTarget[]) {
   return transformPartialPrimitiveTargets(
     partialTargets,
-    flow(canonicalizeScopeTypes, canonicalizeColors)
+    flow(canonicalizeScopeTypes, canonicalizeColors, upgradeStrictHere)
   );
 }

--- a/src/util/canonicalizeTargets.ts
+++ b/src/util/canonicalizeTargets.ts
@@ -52,14 +52,15 @@ const STRICT_HERE = {
   insideOutsideType: "inside",
 };
 
+const IMPLICIT_TARGET: PartialPrimitiveTarget = {
+  type: "primitive",
+  isImplicit: true,
+};
+
 const upgradeStrictHere = (
   target: PartialPrimitiveTarget
 ): PartialPrimitiveTarget =>
-  isDeepStrictEqual(target, STRICT_HERE)
-    ? update(target, {
-        selectionType: () => "strictHere",
-      })
-    : target;
+  isDeepStrictEqual(target, STRICT_HERE) ? IMPLICIT_TARGET : target;
 
 export default function canonicalizeTargets(partialTargets: PartialTarget[]) {
   return transformPartialPrimitiveTargets(


### PR DESCRIPTION
- [x] Switch strict here to instead just have a field `isImplicit`, and no other fields than `type`
- [x] Switch "just" to use `toRawTarget` modifier
- [x] Run test upgrade for strict here
- [x] Upgrade "just" tests (don't need backward compatibility stuff because it's unreleased)
- [x] [WON'T DO] Add backwards compatibility test for strict here 
