### PR TITLE
Fix hats in local tests

### DIFF
--- a/src/core/Decorations.ts
+++ b/src/core/Decorations.ts
@@ -20,6 +20,7 @@ import {
   DEFAULT_VERTICAL_OFFSET_EM,
 } from "./shapeAdjustments";
 import { Graph } from "../typings/Types";
+import isTesting from "../testUtil/isTesting";
 
 export type DecorationMap = {
   [k in HatStyleName]?: vscode.TextEditorDecorationType;
@@ -190,9 +191,9 @@ export default class Decorations {
     shapePenalties.default = 0;
     colorPenalties.default = 0;
 
-    const activeHatColors = HAT_COLORS.filter(
-      (color) => colorEnablement[color]
-    );
+    const activeHatColors = isTesting()
+      ? HAT_COLORS
+      : HAT_COLORS.filter((color) => colorEnablement[color]);
     const activeNonDefaultHatShapes = HAT_NON_DEFAULT_SHAPES.filter(
       (shape) => shapeEnablement[shape]
     );


### PR DESCRIPTION
Ignores hat enablement settings so that tests don't break locally if you've changed your hat enablement