### PR TITLE
Disabled statement block on typescript

### DIFF
--- a/src/languages/typescript.ts
+++ b/src/languages/typescript.ts
@@ -46,7 +46,7 @@ const STATEMENT_TYPES = [
   "lexical_declaration",
   "module",
   "return_statement",
-  "statement_block",
+//   "statement_block", This is disabled since we want the whole statement and not just the block
   "switch_statement",
   "throw_statement",
   "try_statement",

--- a/src/test/suite/fixtures/recorded/languages/typescript/takeState2.yml
+++ b/src/test/suite/fixtures/recorded/languages/typescript/takeState2.yml
@@ -1,0 +1,29 @@
+spokenForm: take state
+languageId: typescript
+command:
+  actionName: setSelection
+  partialTargets:
+    - type: primitive
+      modifier: {type: containingScope, scopeType: statement, includeSiblings: false}
+  extraArgs: []
+initialState:
+  documentContents: |-
+    if (true) {
+
+    }
+  selections:
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    if (true) {
+
+    }
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 2, character: 1}
+  thatMark:
+    - anchor: {line: 0, character: 0}
+      active: {line: 2, character: 1}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: containingScope, scopeType: statement, includeSiblings: false}}]


### PR DESCRIPTION
At the moment a `statement` in typescript will just captured a block/body of if statements and loops. Disabling statement block makes the ancestral crawl find the entire statement instead.