### PR TITLE
Fix doc links

### DIFF
--- a/docs/contributing/adding-a-new-language.md
+++ b/docs/contributing/adding-a-new-language.md
@@ -11,7 +11,7 @@ for how to add support for a new parser
 
 ## 2. Define parse tree patterns in Cursorless
 
-The parse trees exposed by tree-sitter are often pretty close to what we``'re
+The parse trees exposed by tree-sitter are often pretty close to what we're
 looking for, but we often need to look for specific patterns within the parse
 tree to get the scopes that the user expects. Fortunately, we have a
 domain-specific language that makes these definitions fairly compact.
@@ -19,7 +19,7 @@ domain-specific language that makes these definitions fairly compact.
 - Check out the [docs](parse-tree-patterns.md) for the syntax tree pattern
   matcher
 - You may also find it helpful to look at an existing language, such as
-  [java](../src/languages/java.ts).
+  [java](../../src/languages/java.ts).
 - If you look in the debug console, you'll see debug output every time you move
   your cursor, which might be helpful.
 - You will likely want to look at `node-types.json` for your language, (eg [java](https://github.com/tree-sitter/tree-sitter-java/blob/master/src/node-types.json)). This file is generated from `grammar.js`, which might also be helpful to look at (eg [java](https://github.com/tree-sitter/tree-sitter-java/blob/master/grammar.js)).
@@ -29,6 +29,6 @@ domain-specific language that makes these definitions fairly compact.
 Test cases can be automatically recorded, which should speed things up a lot.
 See the [docs](test-case-recorder.md) for the test case recorder. It will also
 likely be helpful to look at the existing recorded test cases (eg
-[java](../src/test/suite/fixtures/recorded/languages/java)) to see how
+[java](../../src/test/suite/fixtures/recorded/languages/java)) to see how
 they
 should end up looking when they're recorded.

--- a/docs/contributing/test-case-recorder.md
+++ b/docs/contributing/test-case-recorder.md
@@ -6,7 +6,7 @@ like `hello world`), positioning your cursor where you want, tell cursorless to
 start recording, and then issue one or more cursorless commands. It works by
 recording the initial state of the file including cursor position(s), the
 command run, and the final state, all in the form of a yaml document. See
-[existing test cases](../src/test/suite/fixtures/recorded) for example outputs.
+[existing test cases](../../src/test/suite/fixtures/recorded) for example outputs.
 
 ## Initial setup
 
@@ -25,7 +25,7 @@ command run, and the final state, all in the form of a yaml document. See
 1. Start debugging (F5)
 1. Create a minimal file to use for recording tests. And position your cursor
    where you'd like. Check out the `initialState.documentContents` field of
-   [existing test cases](../src/test/suite/fixtures/recorded) for examples.
+   [existing test cases](../../src/test/suite/fixtures/recorded) for examples.
 1. Issue the `"cursorless record"` command
    - List of target directories is shown. All test cases will be put into the
      given subdirectory of `src/test/suite/fixtures/recorded`
@@ -68,6 +68,6 @@ To upgrade all the test fixtures to the latest command version, run the command 
 
 1. Add a new transformation to the `src/scripts/transformRecordedTests/transformations` directory. Look at the existing transformations in that directory for inspiration.
 1. Change the value at the `custom` key in `AVAILABLE_TRANSFORMATIONS` at the top of
-   [`transformRecordedTests/index.ts`](../src/scripts/transformRecordedTests/index.ts) to
+   [`transformRecordedTests/index.ts`](../../src/scripts/transformRecordedTests/index.ts) to
    point to your new transformation
 1. Run `yarn run compile && node ./out/scripts/transformRecordedTests/index.js custom`


### PR DESCRIPTION
Some links got messed up when I reorganized the `docs` directory