### PR TITLE
Handle angle brackets within an error node

### DIFF
--- a/src/processTargets/modifiers/surroundingPair/findSurroundingPairParseTreeBased.ts
+++ b/src/processTargets/modifiers/surroundingPair/findSurroundingPairParseTreeBased.ts
@@ -6,6 +6,7 @@ import {
   SurroundingPairDirection,
 } from "../../../typings/Types";
 import { getNodeRange } from "../../../util/nodeSelectors";
+import { isContainedInErrorNode } from "../../../util/treeSitterUtils";
 import { extractSelectionFromSurroundingPairOffsets } from "./extractSelectionFromSurroundingPairOffsets";
 import { findSurroundingPairCore } from "./findSurroundingPairCore";
 import { getIndividualDelimiters } from "./getIndividualDelimiters";
@@ -205,6 +206,7 @@ function findSurroundingPairContainedInNode(
           // looking at its position within its parent node.
           if (
             delimiterInfo.delimiter === "angleBrackets" &&
+            !isContainedInErrorNode(delimiterNode) &&
             inferDelimiterSide(delimiterNode) !== delimiterInfo.side
           ) {
             return undefined;

--- a/src/processTargets/modifiers/surroundingPair/findSurroundingPairParseTreeBased.ts
+++ b/src/processTargets/modifiers/surroundingPair/findSurroundingPairParseTreeBased.ts
@@ -206,8 +206,8 @@ function findSurroundingPairContainedInNode(
           // looking at its position within its parent node.
           if (
             delimiterInfo.delimiter === "angleBrackets" &&
-            !isContainedInErrorNode(delimiterNode) &&
-            inferDelimiterSide(delimiterNode) !== delimiterInfo.side
+            inferDelimiterSide(delimiterNode) !== delimiterInfo.side &&
+            !isContainedInErrorNode(delimiterNode)
           ) {
             return undefined;
           }

--- a/src/test/suite/fixtures/recorded/surroundingPair/parseTree/typescript/clearPair10.yml
+++ b/src/test/suite/fixtures/recorded/surroundingPair/parseTree/typescript/clearPair10.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 1
+  spokenForm: clear pair
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: surroundingPair, delimiter: any}
+initialState:
+  documentContents: foo<bar>
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  marks: {}
+finalState:
+  documentContents: foo
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  thatMark:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}, isImplicit: false}]

--- a/src/test/suite/fixtures/recorded/surroundingPair/parseTree/typescript/clearPair9.yml
+++ b/src/test/suite/fixtures/recorded/surroundingPair/parseTree/typescript/clearPair9.yml
@@ -1,0 +1,23 @@
+languageId: typescript
+command:
+  version: 1
+  spokenForm: clear pair
+  action: clearAndSetSelection
+  targets:
+    - type: primitive
+      modifier: {type: surroundingPair, delimiter: any}
+initialState:
+  documentContents: foo<>
+  selections:
+    - anchor: {line: 0, character: 4}
+      active: {line: 0, character: 4}
+  marks: {}
+finalState:
+  documentContents: foo
+  selections:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+  thatMark:
+    - anchor: {line: 0, character: 3}
+      active: {line: 0, character: 3}
+fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}, isImplicit: false}]

--- a/src/util/treeSitterUtils.ts
+++ b/src/util/treeSitterUtils.ts
@@ -42,22 +42,27 @@ export function getChildNodesForFieldName(
  * `includeNode` is `true`
  * @param node The node to iterate ancestors from
  * @param includeNode Whether to include the node itself in the returned list
- * @returns A list of ancestors possibly including the node itself
+ * @returns A list of ancestors possibly including the includeNode node itself
  */
-export function getAncestors(node: SyntaxNode, includeNode: boolean) {
-  const ancestors = includeNode ? [node] : [];
-  const treeCursor = node.walk();
+export function getAncestors(node: SyntaxNode, includeNode: boolean = true) {
+  const ancestors: SyntaxNode[] = includeNode ? [node] : [];
 
-  let hasNext = treeCursor.gotoParent();
-
-  while (hasNext) {
-    ancestors.push(treeCursor.currentNode());
-    hasNext = treeCursor.gotoParent();
+  for (
+    let currentNode: SyntaxNode | null = node.parent;
+    currentNode != null;
+    currentNode = currentNode.parent
+  ) {
+    ancestors.push(currentNode);
   }
 
   return ancestors;
 }
 
+/**
+ * Determines whether the given node or one of its ancestors is an error node
+ * @param node The node to check
+ * @returns True if the given node is contained in an error node
+ */
 export function isContainedInErrorNode(node: SyntaxNode) {
   const ancestors = getAncestors(node, true);
 

--- a/src/util/treeSitterUtils.ts
+++ b/src/util/treeSitterUtils.ts
@@ -64,7 +64,5 @@ export function getAncestors(node: SyntaxNode, includeNode: boolean = true) {
  * @returns True if the given node is contained in an error node
  */
 export function isContainedInErrorNode(node: SyntaxNode) {
-  const ancestors = getAncestors(node, true);
-
-  return ancestors.some((ancestor) => ancestor.type === "ERROR");
+  return getAncestors(node).some((ancestor) => ancestor.type === "ERROR");
 }

--- a/src/util/treeSitterUtils.ts
+++ b/src/util/treeSitterUtils.ts
@@ -36,3 +36,30 @@ export function getChildNodesForFieldName(
 
   return ret;
 }
+
+/**
+ * Returns a list of the node's ancestors, including the node itself if
+ * `includeNode` is `true`
+ * @param node The node to iterate ancestors from
+ * @param includeNode Whether to include the node itself in the returned list
+ * @returns A list of ancestors possibly including the node itself
+ */
+export function getAncestors(node: SyntaxNode, includeNode: boolean) {
+  const ancestors = includeNode ? [node] : [];
+  const treeCursor = node.walk();
+
+  let hasNext = treeCursor.gotoParent();
+
+  while (hasNext) {
+    ancestors.push(treeCursor.currentNode());
+    hasNext = treeCursor.gotoParent();
+  }
+
+  return ancestors;
+}
+
+export function isContainedInErrorNode(node: SyntaxNode) {
+  const ancestors = getAncestors(node, true);
+
+  return ancestors.some((ancestor) => ancestor.type === "ERROR");
+}


### PR DESCRIPTION
If an angle bracket is contained in an error node, we relax the requirement that it be the first / last child of its parent