### PR TITLE
Filter out single-line targets for `fold` action

### DIFF
--- a/src/actions/Fold.ts
+++ b/src/actions/Fold.ts
@@ -32,9 +32,9 @@ class FoldAction implements Action {
     await commands.executeCommand(this.command, {
       levels: 1,
       direction: "down",
-      selectionLines: targets.map(
-        (target) => target.selection.selection.start.line
-      ),
+      selectionLines: targets
+        .filter((target) => !target.selection.selection.isSingleLine)
+        .map((target) => target.selection.selection.start.line),
     });
 
     // If necessary focus back original editor

--- a/src/actions/Fold.ts
+++ b/src/actions/Fold.ts
@@ -1,4 +1,4 @@
-import { commands } from "vscode";
+import { commands, window } from "vscode";
 import {
   Action,
   ActionPreferences,
@@ -6,10 +6,13 @@ import {
   Graph,
   TypedSelection,
 } from "../typings/Types";
+import { focusEditor } from "../util/setSelectionsAndFocusEditor";
 import { ensureSingleEditor } from "../util/targetUtils";
 
 class FoldAction implements Action {
-  getTargetPreferences: () => ActionPreferences[] = () => [{ insideOutsideType: "outside" }];
+  getTargetPreferences: () => ActionPreferences[] = () => [
+    { insideOutsideType: "inside" },
+  ];
 
   constructor(private command: string) {
     this.run = this.run.bind(this);
@@ -19,15 +22,25 @@ class FoldAction implements Action {
     TypedSelection[],
     TypedSelection[]
   ]): Promise<ActionReturnValue> {
-    ensureSingleEditor(targets);
+    const originalEditor = window.activeTextEditor;
+    const editor = ensureSingleEditor(targets);
+
+    if (originalEditor !== editor) {
+      await focusEditor(editor);
+    }
 
     await commands.executeCommand(this.command, {
       levels: 1,
       direction: "down",
-      selectionLines: targets
-        .filter((target) => !target.selection.selection.isSingleLine)
-        .map((target) => target.selection.selection.start.line),
+      selectionLines: targets.map(
+        (target) => target.selection.selection.start.line
+      ),
     });
+
+    // If necessary focus back original editor
+    if (originalEditor != null && originalEditor !== window.activeTextEditor) {
+      await focusEditor(originalEditor);
+    }
 
     return {
       thatMark: targets.map((target) => target.selection),


### PR DESCRIPTION
This reverts commit 8117983d6ed5b3242855264e6f89079ebad4ecb6 because it broke "fold every state" when one of the statements was a single line