### PR TITLE
Re enable fold single line

### DIFF
--- a/src/actions/Fold.ts
+++ b/src/actions/Fold.ts
@@ -29,16 +29,29 @@ class FoldAction implements Action {
       await focusEditor(editor);
     }
 
+    const singleLineTargets = targets.filter(
+      (target) => target.selection.selection.isSingleLine
+    );
+    const multiLineTargets = targets.filter(
+      (target) => !target.selection.selection.isSingleLine
+    );
+    // Don't mix multi and single line targets.
+    // This is probably the result of an "every" command
+    // and folding the single line targets will fold the parent as well
+    const selectedTargets = multiLineTargets.length
+      ? multiLineTargets
+      : singleLineTargets;
+
     await commands.executeCommand(this.command, {
       levels: 1,
       direction: "down",
-      selectionLines: targets
-        .filter((target) => !target.selection.selection.isSingleLine)
-        .map((target) => target.selection.selection.start.line),
+      selectionLines: selectedTargets.map(
+        (target) => target.selection.selection.start.line
+      ),
     });
 
     // If necessary focus back original editor
-    if (originalEditor != null && originalEditor !== window.activeTextEditor) {
+    if (originalEditor != null && originalEditor !== editor) {
       await focusEditor(originalEditor);
     }
 


### PR DESCRIPTION
Re enabled folding of single line. To "solve" the problem where `fold every state` will fold the parent if one of the states is a single line I added a constraint that you can't combine multi and single line targets. In that case just used the multiline targets. Multiple single line targets is fine though.

fixes #72