### PR TITLE
Fix `that` mark for rewrap action

### DIFF
--- a/src/test/suite/fixtures/recorded/actions/curlyRepackRound.yml
+++ b/src/test/suite/fixtures/recorded/actions/curlyRepackRound.yml
@@ -28,11 +28,7 @@ finalState:
       active: {line: 1, character: 5}
   thatMark:
     - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 0, character: 8}
       active: {line: 0, character: 9}
     - anchor: {line: 1, character: 0}
-      active: {line: 1, character: 1}
-    - anchor: {line: 1, character: 6}
       active: {line: 1, character: 7}
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: parentheses}}]

--- a/src/test/suite/fixtures/recorded/actions/squareRepackHarp.yml
+++ b/src/test/suite/fixtures/recorded/actions/squareRepackHarp.yml
@@ -25,7 +25,5 @@ finalState:
       active: {line: 1, character: 0}
   thatMark:
     - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 0, character: 6}
       active: {line: 0, character: 7}
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: h}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}}]

--- a/src/test/suite/fixtures/recorded/actions/squareRepackLeper.yml
+++ b/src/test/suite/fixtures/recorded/actions/squareRepackLeper.yml
@@ -25,7 +25,5 @@ finalState:
       active: {line: 1, character: 0}
   thatMark:
     - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 0, character: 6}
       active: {line: 0, character: 7}
 fullTargets: [{type: primitive, mark: {type: decoratedSymbol, symbolColor: default, character: (}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}}]

--- a/src/test/suite/fixtures/recorded/actions/squareRepackPair.yml
+++ b/src/test/suite/fixtures/recorded/actions/squareRepackPair.yml
@@ -22,7 +22,5 @@ finalState:
       active: {line: 0, character: 2}
   thatMark:
     - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 0, character: 6}
       active: {line: 0, character: 7}
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}}]

--- a/src/test/suite/fixtures/recorded/actions/squareRepackThis.yml
+++ b/src/test/suite/fixtures/recorded/actions/squareRepackThis.yml
@@ -20,7 +20,5 @@ finalState:
       active: {line: 0, character: 4}
   thatMark:
     - anchor: {line: 0, character: 0}
-      active: {line: 0, character: 1}
-    - anchor: {line: 0, character: 6}
       active: {line: 0, character: 7}
 fullTargets: [{type: primitive, mark: {type: cursor}, selectionType: token, position: contents, insideOutsideType: inside, modifier: {type: surroundingPair, delimiter: any}}]


### PR DESCRIPTION
The `that` mark is now set to be the full delimited range, rather than just the delimiters, to be consistent with the way "wrap" works