### PR TITLE
Fix hat map jitter

### DIFF
--- a/src/core/HatAllocator.ts
+++ b/src/core/HatAllocator.ts
@@ -24,7 +24,6 @@ export class HatAllocator {
       .get<boolean>("showOnStart")!;
 
     this.addDecorationsDebounced = this.addDecorationsDebounced.bind(this);
-    this.addDecorationsDebounced = this.addDecorationsDebounced.bind(this);
     this.toggleDecorations = this.toggleDecorations.bind(this);
     this.clearEditorDecorations = this.clearEditorDecorations.bind(this);
 

--- a/src/core/HatAllocator.ts
+++ b/src/core/HatAllocator.ts
@@ -4,7 +4,7 @@ import { Graph } from "../typings/Types";
 import { Disposable } from "vscode";
 import { IndividualHatMap } from "./IndividualHatMap";
 
-const DECORATION_DEBOUNCE_DELAY = 40;
+const DECORATION_DEBOUNCE_DELAY_MS = 40;
 
 interface Context {
   getActiveMap(): Promise<IndividualHatMap>;
@@ -82,7 +82,7 @@ export class HatAllocator {
     this.timeoutHandle = setTimeout(() => {
       this.addDecorations();
       this.timeoutHandle = null;
-    }, DECORATION_DEBOUNCE_DELAY);
+    }, DECORATION_DEBOUNCE_DELAY_MS);
   }
 
   private toggleDecorations() {


### PR DESCRIPTION
Change timeout for all hat map redecorations to 40ms because it was too jittery at 16ms.  Was slowing down dictation for me, and rapidly pressing the up arrow also caused the hats to flail