### PR TITLE
Configurable debounce delay

### DIFF
--- a/package.json
+++ b/package.json
@@ -115,6 +115,11 @@
 					"default": true,
 					"description": "Whether to show decorations on vscode start."
 				},
+				"cursorless.decorationDebounceDelayMs": {
+					"type": "number",
+					"default": 50,
+					"description": "How quickly to redraw hats in response to scrolling or cursor movement"
+				},
 				"cursorless.debug": {
 					"type": "boolean",
 					"default": false,

--- a/src/core/HatAllocator.ts
+++ b/src/core/HatAllocator.ts
@@ -4,8 +4,6 @@ import { Graph } from "../typings/Types";
 import { Disposable } from "vscode";
 import { IndividualHatMap } from "./IndividualHatMap";
 
-const DECORATION_DEBOUNCE_DELAY_MS = 40;
-
 interface Context {
   getActiveMap(): Promise<IndividualHatMap>;
 }
@@ -78,10 +76,14 @@ export class HatAllocator {
       clearTimeout(this.timeoutHandle);
     }
 
+    const decorationDebounceDelayMs = vscode.workspace
+      .getConfiguration("cursorless")
+      .get<number>("decorationDebounceDelayMs")!;
+
     this.timeoutHandle = setTimeout(() => {
       this.addDecorations();
       this.timeoutHandle = null;
-    }, DECORATION_DEBOUNCE_DELAY_MS);
+    }, decorationDebounceDelayMs);
   }
 
   private toggleDecorations() {


### PR DESCRIPTION
I personally like my debounce delay a bit longer, as otherwise it can cause lagging.  I've reset the default to 50ms, which is what it used to be before I bumped it to 175ms to account for longer command phrases, but now it is configurable for users who want a smaller / larger value