### PR TITLE
Fixed bug where line breakpoint would use incorrectly character

### DIFF
--- a/src/actions/SetBreakpoint.ts
+++ b/src/actions/SetBreakpoint.ts
@@ -46,16 +46,20 @@ export default class SetBreakpoint implements Action {
     const toRemove: Breakpoint[] = [];
 
     targets.forEach((target) => {
+      let range: Range = target.selection.selection;
+      // The action preference give us line content but line breakpoints are registered on character 0
+      if (
+        target.selectionType === "line" ||
+        target.selectionType === "paragraph"
+      ) {
+        range = range.with(range.start.with(undefined, 0), undefined);
+      }
       const uri = target.selection.editor.document.uri;
-      const existing = getBreakpoints(uri, target.selection.selection);
+      const existing = getBreakpoints(uri, range);
       if (existing.length > 0) {
         toRemove.push(...existing);
       } else {
-        toAdd.push(
-          new SourceBreakpoint(
-            new Location(uri, target.selection.selection.start)
-          )
-        );
+        toAdd.push(new SourceBreakpoint(new Location(uri, range)));
       }
     });
 

--- a/src/actions/SetBreakpoint.ts
+++ b/src/actions/SetBreakpoint.ts
@@ -14,6 +14,7 @@ import {
   Breakpoint,
 } from "vscode";
 import displayPendingEditDecorations from "../util/editDisplayUtils";
+import { isLineSelectionType } from "../util/selectionType";
 
 function getBreakpoints(uri: Uri, range: Range) {
   return debug.breakpoints.filter(
@@ -48,10 +49,7 @@ export default class SetBreakpoint implements Action {
     targets.forEach((target) => {
       let range: Range = target.selection.selection;
       // The action preference give us line content but line breakpoints are registered on character 0
-      if (
-        target.selectionType === "line" ||
-        target.selectionType === "paragraph"
-      ) {
+      if (isLineSelectionType(target.selectionType)) {
         range = range.with(range.start.with(undefined, 0), undefined);
       }
       const uri = target.selection.editor.document.uri;
@@ -59,6 +57,9 @@ export default class SetBreakpoint implements Action {
       if (existing.length > 0) {
         toRemove.push(...existing);
       } else {
+        if (isLineSelectionType(target.selectionType)) {
+          range = range.with(undefined, range.end.with(undefined, 0));
+        }
         toAdd.push(new SourceBreakpoint(new Location(uri, range)));
       }
     });

--- a/src/test/suite/breakpoints.test.ts
+++ b/src/test/suite/breakpoints.test.ts
@@ -129,7 +129,7 @@ async function breakpointTokenHarpRemove() {
     ),
   ]);
 
-  assert.deepStrictEqual(vscode.debug.breakpoints.length, 1);
+  assert.deepStrictEqual(vscode.debug.breakpoints.length, 2);
 
   await vscode.commands.executeCommand(
     "cursorless.command",

--- a/src/test/suite/breakpoints.test.ts
+++ b/src/test/suite/breakpoints.test.ts
@@ -1,0 +1,88 @@
+import * as assert from "assert";
+import * as vscode from "vscode";
+import * as sinon from "sinon";
+import { getCursorlessApi } from "../../util/getExtensionApi";
+import { openNewEditor } from "../openNewEditor";
+
+suite("breakpoints", async function () {
+  this.timeout("100s");
+  this.retries(3);
+
+  teardown(() => {
+    sinon.restore();
+  });
+
+  test("breakpoint harp", breakpointHarp);
+  test("breakpoint token harp", breakpointTokenHarp);
+});
+
+async function breakpointHarp() {
+  const graph = (await getCursorlessApi()).graph!;
+
+  await openNewEditor("  hello");
+
+  await graph.hatTokenMap.addDecorations();
+
+  removeBreakpoints();
+
+  await vscode.commands.executeCommand(
+    "cursorless.command",
+    "breakpoint harp",
+    "setBreakpoint",
+    [
+      {
+        type: "primitive",
+        mark: {
+          type: "decoratedSymbol",
+          symbolColor: "default",
+          character: "h",
+        },
+      },
+    ]
+  );
+
+  const breakpoints = vscode.debug.breakpoints;
+
+  assert.deepStrictEqual(breakpoints.length, 1);
+  assert.ok(breakpoints[0] instanceof vscode.SourceBreakpoint);
+  const breakpoint = <vscode.SourceBreakpoint>breakpoints[0];
+  assert.ok(breakpoint.location.range.isEqual(new vscode.Range(0, 0, 0, 0)));
+}
+
+async function breakpointTokenHarp() {
+  const graph = (await getCursorlessApi()).graph!;
+
+  await openNewEditor("  hello");
+
+  await graph.hatTokenMap.addDecorations();
+
+  removeBreakpoints();
+
+  await vscode.commands.executeCommand(
+    "cursorless.command",
+    "breakpoint token harp",
+    "setBreakpoint",
+    [
+      {
+        type: "primitive",
+        selectionType: "token",
+        mark: {
+          type: "decoratedSymbol",
+          symbolColor: "default",
+          character: "h",
+        },
+      },
+    ]
+  );
+
+  const breakpoints = vscode.debug.breakpoints;
+
+  assert.deepStrictEqual(breakpoints.length, 1);
+  assert.ok(breakpoints[0] instanceof vscode.SourceBreakpoint);
+  const breakpoint = <vscode.SourceBreakpoint>breakpoints[0];
+  assert.ok(breakpoint.location.range.isEqual(new vscode.Range(0, 2, 0, 7)));
+}
+
+function removeBreakpoints() {
+  vscode.debug.removeBreakpoints(vscode.debug.breakpoints);
+}

--- a/src/test/suite/breakpoints.test.ts
+++ b/src/test/suite/breakpoints.test.ts
@@ -23,7 +23,7 @@ suite("breakpoints", async function () {
   test("breakpoint harp add", breakpointHarpAdd);
   test("breakpoint token harp add", breakpointTokenHarpAdd);
   test("breakpoint harp remove", breakpointHarpRemove);
-  test("breakpoint Token harp remove", breakpointTokenHarpRemove);
+  test("breakpoint token harp remove", breakpointTokenHarpRemove);
 });
 
 async function breakpointHarpAdd() {

--- a/src/test/suite/breakpoints.test.ts
+++ b/src/test/suite/breakpoints.test.ts
@@ -122,6 +122,9 @@ async function breakpointTokenHarpRemove() {
 
   vscode.debug.addBreakpoints([
     new vscode.SourceBreakpoint(
+      new vscode.Location(editor.document.uri, new vscode.Range(0, 0, 0, 0))
+    ),
+    new vscode.SourceBreakpoint(
       new vscode.Location(editor.document.uri, new vscode.Range(0, 2, 0, 7))
     ),
   ]);
@@ -145,7 +148,11 @@ async function breakpointTokenHarpRemove() {
     ]
   );
 
-  assert.deepStrictEqual(vscode.debug.breakpoints.length, 0);
+  const breakpoints = vscode.debug.breakpoints;
+  assert.deepStrictEqual(breakpoints.length, 1);
+  assert.ok(breakpoints[0] instanceof vscode.SourceBreakpoint);
+  const breakpoint = <vscode.SourceBreakpoint>breakpoints[0];
+  assert.ok(breakpoint.location.range.isEqual(new vscode.Range(0, 0, 0, 0)));
 }
 
 function removeBreakpoints() {

--- a/src/test/suite/breakpoints.test.ts
+++ b/src/test/suite/breakpoints.test.ts
@@ -8,6 +8,10 @@ suite("breakpoints", async function () {
   this.timeout("100s");
   this.retries(3);
 
+  setup(() => {
+    removeBreakpoints();
+  });
+
   teardown(() => {
     sinon.restore();
   });
@@ -16,18 +20,16 @@ suite("breakpoints", async function () {
     removeBreakpoints();
   });
 
-  test("breakpoint harp", breakpointHarp);
-  test("breakpoint token harp", breakpointTokenHarp);
+  test("breakpoint harp add", breakpointHarpAdd);
+  test("breakpoint token harp add", breakpointTokenHarpAdd);
+  test("breakpoint harp remove", breakpointHarpRemove);
+  test("breakpoint Token harp remove", breakpointTokenHarpRemove);
 });
 
-async function breakpointHarp() {
+async function breakpointHarpAdd() {
   const graph = (await getCursorlessApi()).graph!;
-
   await openNewEditor("  hello");
-
   await graph.hatTokenMap.addDecorations();
-
-  removeBreakpoints();
 
   await vscode.commands.executeCommand(
     "cursorless.command",
@@ -46,21 +48,16 @@ async function breakpointHarp() {
   );
 
   const breakpoints = vscode.debug.breakpoints;
-
   assert.deepStrictEqual(breakpoints.length, 1);
   assert.ok(breakpoints[0] instanceof vscode.SourceBreakpoint);
   const breakpoint = <vscode.SourceBreakpoint>breakpoints[0];
   assert.ok(breakpoint.location.range.isEqual(new vscode.Range(0, 0, 0, 0)));
 }
 
-async function breakpointTokenHarp() {
+async function breakpointTokenHarpAdd() {
   const graph = (await getCursorlessApi()).graph!;
-
   await openNewEditor("  hello");
-
   await graph.hatTokenMap.addDecorations();
-
-  removeBreakpoints();
 
   await vscode.commands.executeCommand(
     "cursorless.command",
@@ -80,11 +77,75 @@ async function breakpointTokenHarp() {
   );
 
   const breakpoints = vscode.debug.breakpoints;
-
   assert.deepStrictEqual(breakpoints.length, 1);
   assert.ok(breakpoints[0] instanceof vscode.SourceBreakpoint);
   const breakpoint = <vscode.SourceBreakpoint>breakpoints[0];
   assert.ok(breakpoint.location.range.isEqual(new vscode.Range(0, 2, 0, 7)));
+}
+
+async function breakpointHarpRemove() {
+  const graph = (await getCursorlessApi()).graph!;
+  const editor = await openNewEditor("  hello");
+  await graph.hatTokenMap.addDecorations();
+
+  vscode.debug.addBreakpoints([
+    new vscode.SourceBreakpoint(
+      new vscode.Location(editor.document.uri, new vscode.Range(0, 0, 0, 0))
+    ),
+  ]);
+
+  assert.deepStrictEqual(vscode.debug.breakpoints.length, 1);
+
+  await vscode.commands.executeCommand(
+    "cursorless.command",
+    "breakpoint harp",
+    "setBreakpoint",
+    [
+      {
+        type: "primitive",
+        mark: {
+          type: "decoratedSymbol",
+          symbolColor: "default",
+          character: "h",
+        },
+      },
+    ]
+  );
+
+  assert.deepStrictEqual(vscode.debug.breakpoints.length, 0);
+}
+
+async function breakpointTokenHarpRemove() {
+  const graph = (await getCursorlessApi()).graph!;
+  const editor = await openNewEditor("  hello");
+  await graph.hatTokenMap.addDecorations();
+
+  vscode.debug.addBreakpoints([
+    new vscode.SourceBreakpoint(
+      new vscode.Location(editor.document.uri, new vscode.Range(0, 2, 0, 7))
+    ),
+  ]);
+
+  assert.deepStrictEqual(vscode.debug.breakpoints.length, 1);
+
+  await vscode.commands.executeCommand(
+    "cursorless.command",
+    "breakpoint token harp",
+    "setBreakpoint",
+    [
+      {
+        type: "primitive",
+        selectionType: "token",
+        mark: {
+          type: "decoratedSymbol",
+          symbolColor: "default",
+          character: "h",
+        },
+      },
+    ]
+  );
+
+  assert.deepStrictEqual(vscode.debug.breakpoints.length, 0);
 }
 
 function removeBreakpoints() {

--- a/src/test/suite/breakpoints.test.ts
+++ b/src/test/suite/breakpoints.test.ts
@@ -12,6 +12,10 @@ suite("breakpoints", async function () {
     sinon.restore();
   });
 
+  suiteTeardown(() => {
+    removeBreakpoints();
+  });
+
   test("breakpoint harp", breakpointHarp);
   test("breakpoint token harp", breakpointTokenHarp);
 });


### PR DESCRIPTION
Line level breakpoints are always on character 0. This new implementation is consistent with the built in vscode breakpoint functions in regard to line and inline breakpoints.