### PR TITLE
Publish extension on merge to main

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,31 @@
+name: Deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 16
+          cache: yarn
+      - run: yarn install --frozen-lockfile
+      - run: yarn run compile
+      - run: yarn run prepare-for-extension-publish
+      - name: Publish to Open VSX Registry
+        uses: HaaLeo/publish-vscode-extension@v1
+        id: publishToOpenVSX
+        with:
+          pat: ${{ secrets.OPEN_VSX_TOKEN }}
+      - name: Publish to Visual Studio Marketplace
+        uses: HaaLeo/publish-vscode-extension@v1
+        with:
+          pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
+          registryUrl: https://marketplace.visualstudio.com
+          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,13 +1,15 @@
 name: Deploy
 
 on:
-  push:
-    branches:
-      - main
+  workflow_run:
+    workflows: [Run Tests]
+    types: [completed]
+    branches: [main]
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: production
     steps:
       - uses: actions/checkout@v2

--- a/package.json
+++ b/package.json
@@ -476,13 +476,15 @@
 		"watch": "tsc -watch -p ./",
 		"pretest": "yarn run compile && yarn run lint && yarn run esbuild",
 		"lint": "eslint src --ext ts",
-		"test": "env CURSORLESS_TEST=true node ./out/test/runTest.js"
+		"test": "env CURSORLESS_TEST=true node ./out/test/runTest.js",
+		"prepare-for-extension-publish": "node ./out/scripts/prepareForExtensionPublish.js"
 	},
 	"devDependencies": {
 		"@types/glob": "^7.1.3",
 		"@types/js-yaml": "^4.0.2",
 		"@types/mocha": "^8.0.4",
 		"@types/node": "^16.11.3",
+		"@types/semver": "^7.3.9",
 		"@types/sinon": "^10.0.2",
 		"@types/vscode": "^1.61.0",
 		"@typescript-eslint/eslint-plugin": "^4.9.0",
@@ -494,6 +496,7 @@
 		"js-yaml": "^4.1.0",
 		"mocha": "^8.1.3",
 		"npm-license-crawler": "^0.2.1",
+		"semver": "^7.3.5",
 		"sinon": "^11.1.1",
 		"typescript": "^4.4.4",
 		"vscode-test": "^1.4.1"

--- a/src/scripts/prepareForExtensionPublish.ts
+++ b/src/scripts/prepareForExtensionPublish.ts
@@ -15,7 +15,7 @@ const execAsync = promisify(exec);
 async function main() {
   const { major, minor } = semver.parse(process.env.npm_package_version)!;
 
-  const commitCount = await runCommand("git rev-list --count head");
+  const commitCount = await runCommand("git rev-list --count HEAD");
 
   const newVersion = `${major}.${minor}.${commitCount}`;
 
@@ -26,24 +26,21 @@ async function main() {
   const repository = process.env["GITHUB_REPOSITORY"];
   const runId = process.env["GITHUB_RUN_ID"];
 
+  if (repository == null) {
+    throw new Error("Missing environment variable GITHUB_REPOSITORY");
+  }
+
+  if (runId == null) {
+    throw new Error("Missing environment variable GITHUB_RUN_ID");
+  }
+
   await writeFile(
     "build-info.json",
     JSON.stringify({
-      gitSha: strip(await runCommand("git rev-parse HEAD")),
+      gitSha: (await runCommand("git rev-parse HEAD")).trim(),
       buildUrl: `https://github.com/${repository}/actions/runs/${runId}`,
     })
   );
-}
-
-/**
- * Strips leading and trailing whitespace from string
- *
- * From https://stackoverflow.com/a/1418059
- * @param str The string to process
- * @returns The stripped string
- */
-function strip(str: string): string {
-  return str.replace(/^\s+|\s+$/g, "");
 }
 
 async function runCommand(command: string) {

--- a/src/scripts/prepareForExtensionPublish.ts
+++ b/src/scripts/prepareForExtensionPublish.ts
@@ -21,6 +21,8 @@ async function main() {
 
   await runCommand(`npm --no-git-tag-version version ${newVersion}`);
 
+  // These are automatically set for Github actions
+  // See https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
   const repository = process.env["GITHUB_REPOSITORY"];
   const runId = process.env["GITHUB_RUN_ID"];
 

--- a/src/scripts/prepareForExtensionPublish.ts
+++ b/src/scripts/prepareForExtensionPublish.ts
@@ -1,0 +1,57 @@
+import * as semver from "semver";
+import { exec } from "child_process";
+import { promisify } from "util";
+import { writeFile } from "fs/promises";
+
+const execAsync = promisify(exec);
+
+/**
+ * Prepares the directory for extension publication. Does the following:
+ *
+ * 1. Changes the package version so that the patch number is the number of
+ *    commits on the current branch
+ * 2. Writes a file called `build-info.json` for provenance
+ */
+async function main() {
+  const { major, minor } = semver.parse(process.env.npm_package_version)!;
+
+  const commitCount = await runCommand("git rev-list --count head");
+
+  const newVersion = `${major}.${minor}.${commitCount}`;
+
+  await runCommand(`npm --no-git-tag-version version ${newVersion}`);
+
+  const repository = process.env["GITHUB_REPOSITORY"];
+  const runId = process.env["GITHUB_RUN_ID"];
+
+  await writeFile(
+    "build-info.json",
+    JSON.stringify({
+      gitSha: strip(await runCommand("git rev-parse HEAD")),
+      buildUrl: `https://github.com/${repository}/actions/runs/${runId}`,
+    })
+  );
+}
+
+/**
+ * Strips leading and trailing whitespace from string
+ *
+ * From https://stackoverflow.com/a/1418059
+ * @param str The string to process
+ * @returns The stripped string
+ */
+function strip(str: string): string {
+  return str.replace(/^\s+|\s+$/g, "");
+}
+
+async function runCommand(command: string) {
+  const { stdout, stderr } = await execAsync(command);
+
+  if (stderr) {
+    throw new Error(stderr);
+  }
+
+  return stdout;
+}
+
+main();

--- a/yarn.lock
+++ b/yarn.lock
@@ -136,6 +136,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-16.11.3.tgz#fad0b069ec205b0e81429c805d306d2c12e26be1"
   integrity sha512-aIYL9Eemcecs1y77XzFGiSc+FdfN58k4J23UEe6+hynf4Wd9g4DzQPwIKL080vSMuubFqy2hWwOzCtJdc6vFKw==
 
+"@types/semver@^7.3.9":
+  version "7.3.9"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-7.3.9.tgz#152c6c20a7688c30b967ec1841d31ace569863fc"
+  integrity sha512-L/TMpyURfBkf+o/526Zb6kd/tchUP3iBDEPjqjb+U2MAJhVRxxrmr2fwpe08E7QsV7YLcpq0tUaQ9O9x97ZIxQ==
+
 "@types/sinon@^10.0.2":
   version "10.0.2"
   resolved "https://registry.yarnpkg.com/@types/sinon/-/sinon-10.0.2.tgz#f360d2f189c0fd433d14aeb97b9d705d7e4cc0e4"
@@ -1139,9 +1144,9 @@ levn@^0.4.1:
     prelude-ls "^1.2.1"
     type-check "~0.4.0"
 
-"license-checker@git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893":
+"license-checker@git+https://github.com/mwittig/license-checker#d546e3f738e14c62e732346fa355162d46700893":
   version "1.0.0"
-  resolved "git+https://github.com/mwittig/license-checker.git#d546e3f738e14c62e732346fa355162d46700893"
+  resolved "git+https://github.com/mwittig/license-checker#d546e3f738e14c62e732346fa355162d46700893"
   dependencies:
     chalk "~0.5.1"
     mkdirp "^0.3.5"
@@ -1566,6 +1571,13 @@ semver@^7.2.1, semver@^7.3.2:
   version "7.3.4"
   resolved "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz"
   integrity sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+  dependencies:
+    lru-cache "^6.0.0"
+
+semver@^7.3.5:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
   dependencies:
     lru-cache "^6.0.0"
 


### PR DESCRIPTION
This is the first step in our moved to continuous delivery (#17). This PR adds a Github action which automatically releases the extension every time we merge to main. It uses a version number which is automatically generated from the commit number. 

We will move to automatically deploying the talon files once we moved to a mono repo. It is safe to just begin with the extension publication because we are careful about backwards compatibility in this direction