### PR TITLE
Add cursorless settings command

### DIFF
--- a/cursorless-talon/src/cursorless.talon
+++ b/cursorless-talon/src/cursorless.talon
@@ -25,7 +25,6 @@ cursorless docks:          user.cursorless_open_instructions()
 cursorless reference:      user.cursorless_cheat_sheet_show_html()
 cursorless cheat sheet:    user.cursorless_cheat_sheet_show_html()
 cursorless settings:
-    sleep(50ms)
     user.vscode("workbench.action.openGlobalSettings")
     sleep(250ms)
     insert("cursorless")


### PR DESCRIPTION
It's a bit awkward to access Cursorless VSCode settings by voice today.  I was hoping to show how to do so in the new tutorial, but would be nice if it were an easier way to show them

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
