### PR TITLE
Initial talon language support

### DIFF
--- a/cursorless-talon/src/modifiers/scopes.py
+++ b/cursorless-talon/src/modifiers/scopes.py
@@ -77,6 +77,8 @@ scope_types = {
     "paragraph": "namedParagraph",
     "subparagraph": "subParagraph",
     "environment": "environment",
+    # Talon
+    "command": "command",
 }
 
 

--- a/packages/common/src/types/command/PartialTargetDescriptor.types.ts
+++ b/packages/common/src/types/command/PartialTargetDescriptor.types.ts
@@ -130,7 +130,9 @@ export type SimpleScopeTypeType =
   | "identifier"
   | "nonWhitespaceSequence"
   | "boundedNonWhitespaceSequence"
-  | "url";
+  | "url"
+  // Talon
+  | "command";
 
 export interface SimpleScopeType {
   type: SimpleScopeTypeType;

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearArg.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearArg.yml
@@ -1,0 +1,30 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear arg
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        user.do_something(1, "hello")
+        
+        
+  selections:
+    - anchor: {line: 1, character: 22}
+      active: {line: 1, character: 22}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        user.do_something(, "hello")
+        
+        
+  selections:
+    - anchor: {line: 1, character: 22}
+      active: {line: 1, character: 22}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearArg2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearArg2.yml
@@ -1,0 +1,30 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear arg
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        user.do_something(1, "hello")
+        
+        
+  selections:
+    - anchor: {line: 1, character: 32}
+      active: {line: 1, character: 32}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        user.do_something(1, )
+        
+        
+  selections:
+    - anchor: {line: 1, character: 25}
+      active: {line: 1, character: 25}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearArg3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearArg3.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear arg
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        key(enter)
+        
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        key()
+        
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearArg4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearArg4.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear arg
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        sleep(200ms)
+        
+  selections:
+    - anchor: {line: 1, character: 10}
+      active: {line: 1, character: 10}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        sleep()
+        
+  selections:
+    - anchor: {line: 1, character: 10}
+      active: {line: 1, character: 10}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCall.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCall.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear call
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCall}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    slap: key(end enter)
+        
+        
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  marks: {}
+finalState:
+  documentContents: |-
+    slap: 
+        
+        
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCall2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCall2.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear call
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCall}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    sleep: sleep(200ms)
+        
+        
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: |-
+    sleep: 
+        
+        
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCall3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCall3.yml
@@ -1,0 +1,32 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear call
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCall}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        value = user.get_value()
+
+        
+        
+  selections:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        value = 
+
+        
+        
+  selections:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCall4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCall4.yml
@@ -1,0 +1,30 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear call
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCall}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        user.do_something()
+        
+        
+  selections:
+    - anchor: {line: 1, character: 22}
+      active: {line: 1, character: 22}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCallee.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCallee.yml
@@ -1,0 +1,30 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear callee
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: functionCallee}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        user.do_something()
+        
+        
+  selections:
+    - anchor: {line: 1, character: 22}
+      active: {line: 1, character: 22}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        ()
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCommand.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCommand.yml
@@ -1,0 +1,25 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear command
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: command}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    slap:
+        key(end)
+        key(enter)
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCondition.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCondition.yml
@@ -1,0 +1,26 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear condition
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: condition}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    mode: command
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCoreCommand.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCoreCommand.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear core command
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: interiorOnly}
+        - type: containingScope
+          scopeType: {type: command}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    slap:
+        key(end)
+        key(enter)
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    slap:
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCoreEveryCommand.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearCoreEveryCommand.yml
@@ -1,0 +1,29 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear core every command
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - {type: interiorOnly}
+        - type: everyScope
+          scopeType: {type: command}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    air: "a"
+    bat: "b"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    air: 
+    bat: 
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+    - anchor: {line: 1, character: 5}
+      active: {line: 1, character: 5}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryArg.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryArg.yml
@@ -1,0 +1,32 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every arg
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        user.do_something(1, "hello")
+        
+        
+  selections:
+    - anchor: {line: 1, character: 22}
+      active: {line: 1, character: 22}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        user.do_something(, )
+        
+        
+  selections:
+    - anchor: {line: 1, character: 22}
+      active: {line: 1, character: 22}
+    - anchor: {line: 1, character: 24}
+      active: {line: 1, character: 24}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryArg2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryArg2.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every arg
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        key(enter)
+        
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        key()
+        
+  selections:
+    - anchor: {line: 1, character: 8}
+      active: {line: 1, character: 8}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryArg3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryArg3.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every arg
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: argumentOrParameter}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        sleep(200ms)
+        
+  selections:
+    - anchor: {line: 1, character: 10}
+      active: {line: 1, character: 10}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        sleep()
+        
+  selections:
+    - anchor: {line: 1, character: 10}
+      active: {line: 1, character: 10}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryCall.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryCall.yml
@@ -1,0 +1,38 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every call
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: functionCall}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        user.do_something()
+        sleep(200ms)
+        key(enter)
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        
+        
+        
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryCommand.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryCommand.yml
@@ -1,0 +1,27 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every command
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: command}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    air: "a"
+    bat: "b"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |+
+
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryCondition.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryCondition.yml
@@ -1,0 +1,42 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every condition
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: condition}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    mode: command
+    os: linux
+    and tag: user.some_tag
+    not tag: user.some_other_tag
+    and not app: some_application
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+
+
+
+
+
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryKey.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryKey.yml
@@ -1,0 +1,42 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    mode: command
+    os: linux
+    and tag: user.some_tag
+    not tag: user.some_other_tag
+    and not app: some_application
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    : command
+    : linux
+    : user.some_tag
+    : user.some_other_tag
+    : some_application
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 3, character: 0}
+      active: {line: 3, character: 0}
+    - anchor: {line: 4, character: 0}
+      active: {line: 4, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryKey2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryKey2.yml
@@ -1,0 +1,50 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    tag(): user.some_tag
+
+    settings():
+        speech.debug = 1
+
+    command: "command"
+    key(enter): "enter"
+    gamepad(north): "north"
+    face(smile): "smile"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    : user.some_tag
+
+    :
+        speech.debug = 1
+
+    : "command"
+    : "enter"
+    : "north"
+    : "smile"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 5, character: 0}
+      active: {line: 5, character: 0}
+    - anchor: {line: 6, character: 0}
+      active: {line: 6, character: 0}
+    - anchor: {line: 7, character: 0}
+      active: {line: 7, character: 0}
+    - anchor: {line: 8, character: 0}
+      active: {line: 8, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryName.yml
@@ -1,0 +1,42 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    mode: command
+    os: linux
+    and tag: user.some_tag
+    not tag: user.some_other_tag
+    and not app: some_application
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    : command
+    : linux
+    and : user.some_tag
+    not : user.some_other_tag
+    and not : some_application
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 1, character: 0}
+      active: {line: 1, character: 0}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}
+    - anchor: {line: 4, character: 8}
+      active: {line: 4, character: 8}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryName2.yml
@@ -1,0 +1,50 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    tag(): user.some_tag
+
+    settings():
+        speech.debug = 1
+
+    command: "command"
+    key(enter): "enter"
+    gamepad(north): "north"
+    face(smile): "smile"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    : user.some_tag
+
+    :
+        speech.debug = 1
+
+    : "command"
+    : "enter"
+    : "north"
+    : "smile"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+    - anchor: {line: 2, character: 0}
+      active: {line: 2, character: 0}
+    - anchor: {line: 5, character: 0}
+      active: {line: 5, character: 0}
+    - anchor: {line: 6, character: 0}
+      active: {line: 6, character: 0}
+    - anchor: {line: 7, character: 0}
+      active: {line: 7, character: 0}
+    - anchor: {line: 8, character: 0}
+      active: {line: 8, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryState.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryState.yml
@@ -1,0 +1,30 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    settings():
+        speech.debug = 1
+        speech.timeout = 0.4
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    settings():
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryState2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryState2.yml
@@ -1,0 +1,34 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    slap:
+        key(end)
+        key(enter)
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    slap:
+        
+        
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryState3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryState3.yml
@@ -1,0 +1,38 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        user.do_something()
+        sleep(200ms)
+        key(enter)
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        
+        
+        
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+    - anchor: {line: 2, character: 4}
+      active: {line: 2, character: 4}
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryValue.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryValue.yml
@@ -1,0 +1,42 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    mode: command
+    os: linux
+    and tag: user.some_tag
+    not tag: user.some_other_tag
+    and not app: some_application
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    mode: 
+    os: 
+    and tag: 
+    not tag: 
+    and not app: 
+    -
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}
+    - anchor: {line: 1, character: 3}
+      active: {line: 1, character: 3}
+    - anchor: {line: 2, character: 8}
+      active: {line: 2, character: 8}
+    - anchor: {line: 3, character: 8}
+      active: {line: 3, character: 8}
+    - anchor: {line: 4, character: 12}
+      active: {line: 4, character: 12}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryValue2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryValue2.yml
@@ -1,0 +1,30 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    settings():
+        speech.debug = 1
+        speech.timeout = 0.4
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    settings():
+        speech.debug = 
+        speech.timeout = 
+  selections:
+    - anchor: {line: 1, character: 19}
+      active: {line: 1, character: 19}
+    - anchor: {line: 2, character: 21}
+      active: {line: 2, character: 21}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryValue3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearEveryValue3.yml
@@ -1,0 +1,50 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear every value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: everyScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    tag(): user.some_tag
+
+    settings():
+        speech.debug = 1
+
+    command: "command"
+    key(enter): "enter"
+    gamepad(north): "north"
+    face(smile): "smile"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    tag(): 
+
+    settings():
+        
+
+    command: 
+    key(enter): 
+    gamepad(north): 
+    face(smile): 
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+    - anchor: {line: 3, character: 4}
+      active: {line: 3, character: 4}
+    - anchor: {line: 5, character: 9}
+      active: {line: 5, character: 9}
+    - anchor: {line: 6, character: 12}
+      active: {line: 6, character: 12}
+    - anchor: {line: 7, character: 16}
+      active: {line: 7, character: 16}
+    - anchor: {line: 8, character: 13}
+      active: {line: 8, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey.yml
@@ -1,0 +1,26 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    and not mode: command
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    : command
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey2.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    slap:
+        key(end)
+        key(enter)
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |
+    :
+        key(end)
+        key(enter)
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey3.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "air: \"a\""
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+finalState:
+  documentContents: ": \"a\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey4.yml
@@ -1,0 +1,32 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        value = user.get_value()
+
+        
+        
+  selections:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+         = user.get_value()
+
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey5.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "tag(): user.some_tag"
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  marks: {}
+finalState:
+  documentContents: ": user.some_tag"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey6.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey6.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "key(enter): \"enter\""
+  selections:
+    - anchor: {line: 0, character: 19}
+      active: {line: 0, character: 19}
+  marks: {}
+finalState:
+  documentContents: ": \"enter\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey7.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey7.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "gamepad(north): \"north\""
+  selections:
+    - anchor: {line: 0, character: 23}
+      active: {line: 0, character: 23}
+  marks: {}
+finalState:
+  documentContents: ": \"north\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey8.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey8.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "parrot(pop): \"pop\""
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}
+  marks: {}
+finalState:
+  documentContents: ": \"pop\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey9.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearKey9.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear key
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: collectionKey}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "face(smile): \"smile\""
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  marks: {}
+finalState:
+  documentContents: ": \"smile\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName.yml
@@ -1,0 +1,26 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    and not mode: command
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    and not : command
+    -
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName2.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    slap:
+        key(end)
+        key(enter)
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    :
+        key(end)
+        key(enter)
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName3.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "air: \"a\""
+  selections:
+    - anchor: {line: 0, character: 8}
+      active: {line: 0, character: 8}
+  marks: {}
+finalState:
+  documentContents: ": \"a\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName4.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "tag(): user.some_tag"
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  marks: {}
+finalState:
+  documentContents: ": user.some_tag"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName5.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "key(enter): \"enter\""
+  selections:
+    - anchor: {line: 0, character: 19}
+      active: {line: 0, character: 19}
+  marks: {}
+finalState:
+  documentContents: ": \"enter\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName6.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName6.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "gamepad(north): \"north\""
+  selections:
+    - anchor: {line: 0, character: 23}
+      active: {line: 0, character: 23}
+  marks: {}
+finalState:
+  documentContents: ": \"north\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName7.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName7.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "parrot(pop): \"pop\""
+  selections:
+    - anchor: {line: 0, character: 18}
+      active: {line: 0, character: 18}
+  marks: {}
+finalState:
+  documentContents: ": \"pop\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName8.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearName8.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear name
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: name}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "face(smile): \"smile\""
+  selections:
+    - anchor: {line: 0, character: 20}
+      active: {line: 0, character: 20}
+  marks: {}
+finalState:
+  documentContents: ": \"smile\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState.yml
@@ -1,0 +1,24 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    air: "a"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |+
+
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState2.yml
@@ -1,0 +1,26 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    slap:
+        key(end)
+        key(enter)
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |+
+
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState3.yml
@@ -1,0 +1,25 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    settings():
+        speech.debug = 1
+        speech.timeout = 0.4
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: ""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState4.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    settings():
+        speech.debug = 1
+        speech.timeout = 0.4
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    settings():
+        
+        speech.timeout = 0.4
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState5.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    slap: key(end enter)
+        
+        
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}
+  marks: {}
+finalState:
+  documentContents: |-
+    slap: 
+        
+        
+  selections:
+    - anchor: {line: 0, character: 6}
+      active: {line: 0, character: 6}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState6.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState6.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        value = 1 + 1
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState7.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState7.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        value = user.get_value() 
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+         
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState8.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState8.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    sleep: sleep(200ms)
+        
+        
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}
+  marks: {}
+finalState:
+  documentContents: |-
+    sleep: 
+        
+        
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState9.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearState9.yml
@@ -1,0 +1,32 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear state
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: statement}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        value = user.get_value()
+
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        
+
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue.yml
@@ -1,0 +1,26 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    and not mode: command
+    -
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    and not mode: 
+    -
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue10.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue10.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "parrot(pop): \"pop\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "parrot(pop): "
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue11.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue11.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "face(smile): \"smile\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "face(smile): "
+  selections:
+    - anchor: {line: 0, character: 13}
+      active: {line: 0, character: 13}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue2.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue2.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "air: \"a\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "air: "
+  selections:
+    - anchor: {line: 0, character: 5}
+      active: {line: 0, character: 5}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue3.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue3.yml
@@ -1,0 +1,27 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |
+    slap:
+        key(end)
+        key(enter)
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |
+    slap:
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue4.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue4.yml
@@ -1,0 +1,28 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    settings():
+        speech.debug = 1
+        speech.timeout = 0.4
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    settings():
+        speech.debug = 
+        speech.timeout = 0.4
+  selections:
+    - anchor: {line: 1, character: 19}
+      active: {line: 1, character: 19}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue5.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue5.yml
@@ -1,0 +1,27 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    settings():
+        speech.debug = 1
+        speech.timeout = 0.4
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: |-
+    settings():
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue6.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue6.yml
@@ -1,0 +1,32 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: |-
+    some command: 
+        value = user.get_value()
+
+        
+        
+  selections:
+    - anchor: {line: 1, character: 4}
+      active: {line: 1, character: 4}
+  marks: {}
+finalState:
+  documentContents: |-
+    some command: 
+        value = 
+
+        
+        
+  selections:
+    - anchor: {line: 1, character: 12}
+      active: {line: 1, character: 12}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue7.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue7.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "key(enter): \"enter\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "key(enter): "
+  selections:
+    - anchor: {line: 0, character: 12}
+      active: {line: 0, character: 12}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue8.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue8.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "tag(): user.some_tag"
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "tag(): "
+  selections:
+    - anchor: {line: 0, character: 7}
+      active: {line: 0, character: 7}

--- a/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue9.yml
+++ b/packages/cursorless-vscode-e2e/src/suite/fixtures/recorded/languages/talon/clearValue9.yml
@@ -1,0 +1,22 @@
+languageId: talon
+command:
+  version: 5
+  spokenForm: clear value
+  action: {name: clearAndSetSelection}
+  targets:
+    - type: primitive
+      modifiers:
+        - type: containingScope
+          scopeType: {type: value}
+  usePrePhraseSnapshot: true
+initialState:
+  documentContents: "gamepad(north): \"north\""
+  selections:
+    - anchor: {line: 0, character: 0}
+      active: {line: 0, character: 0}
+  marks: {}
+finalState:
+  documentContents: "gamepad(north): "
+  selections:
+    - anchor: {line: 0, character: 16}
+      active: {line: 0, character: 16}

--- a/queries/talon.scm
+++ b/queries/talon.scm
@@ -51,8 +51,8 @@
 ;;!        ################
 (_
   (command_declaration
-    right: (_) @_.interior
-  ) @statement
+    right: (_) @command.interior
+  ) @command @statement
 ) @_.iteration
 
 ;;!! settings()
@@ -60,9 +60,7 @@
 ;;!  ^^^^^^^^^^^^^^^^^^^^
 ;;!      ################
 (_
-  (settings_declaration
-    right: (_) @_.interior
-  ) @statement
+  (settings_declaration) @statement
 ) @_.iteration
 
 ;;!! key(enter)
@@ -73,6 +71,7 @@
   (_
     [
       (key_action)
+      (sleep_action)
       (action)
     ] @functionCall
   )
@@ -93,6 +92,9 @@
 ;;!! key(enter)
 ;;!      ^^^^^
 (key_action
+  arguments: (_) @argumentOrParameter @_.iteration
+)
+(sleep_action
   arguments: (_) @argumentOrParameter @_.iteration
 )
 


### PR DESCRIPTION
Resolves https://github.com/cursorless-dev/cursorless/issues/817

**Condition**
- [x] context match
- [x] every context match

**Command**
- [x] command
- [x] every command

**Statement**
- [x] command line
- [x] command block
- [x] settings block
- [x] script action call
- [x] script key action call
- [x] script sleep action call
- [x] script assignment
- [ ] every statement in file
- [x] every statement in command block
- [x] every statement in settings block

**Name / Collection key**
- [x] context match left
- [x] command left
- [x] settings block left
- [x] setting left
- [x] tag() left
- [x] key() left
- [x] gamepad() left
- [x] face() left
- [x] parrot() left
- [x] every name/key in context block
- [x] every name/key in file

**Value** 
- [x] context match right
- [x] command right
- [x] settings block right
- [x] setting right
- [x] tag() right
- [x] key() right
- [x] gamepad() right
- [x] face() right
- [x] parrot() right
- [x] every value in context block
- [x] every value in settings block
- [x] every value in file

**Interior**
- [x] command right
- [ ] settings block right
- [x] every command interior in file

**Function call**
- [x] action
- [x] key action
- [x] sleep action
- [x] every call in command block

**Function callee**
- [x] action
- [ ] key action
- [ ] sleep action
- [ ] every callee in command block

**Argument or parameter**
- [x] action
- [x] key action
- [x] sleep action
- [x] every argument in action

**Miscellaneous**
- [ ] Update Tree sitter `implicit_string`

## Checklist

- [x] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
