### PR TITLE
Add `isToken` property to `Target`

### DIFF
--- a/packages/cursorless-engine/src/processTargets/marks/CursorStage.ts
+++ b/packages/cursorless-engine/src/processTargets/marks/CursorStage.ts
@@ -16,6 +16,7 @@ export default class CursorStage implements MarkStage {
           isReversed: selection.selection.isReversed,
           contentRange: selection.selection,
           hasExplicitRange: !selection.selection.isEmpty,
+          isToken: false,
         }),
     );
   }

--- a/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/CharacterScopeHandler.ts
+++ b/packages/cursorless-engine/src/processTargets/modifiers/scopeHandlers/CharacterScopeHandler.ts
@@ -38,6 +38,7 @@ export default class CharacterScopeHandler extends NestedScopeHandler {
             editor,
             contentRange: range,
             isReversed,
+            isToken: false,
           }),
       }),
     );

--- a/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
+++ b/packages/cursorless-engine/src/processTargets/targetUtil/createContinuousRange.ts
@@ -63,5 +63,6 @@ export function createContinuousRangeUntypedTarget(
       includeStart,
       includeEnd,
     ),
+    isToken: startTarget.isToken && endTarget.isToken,
   });
 }

--- a/packages/cursorless-engine/src/processTargets/targets/BaseTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/BaseTarget.ts
@@ -31,6 +31,7 @@ export interface CloneWithParameters {
 export default abstract class BaseTarget implements Target {
   protected readonly state: CommonTargetParameters;
   isLine = false;
+  isToken = true;
   hasExplicitScopeType = true;
   hasExplicitRange = true;
   isRaw = false;

--- a/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/ImplicitTarget.ts
@@ -11,6 +11,7 @@ export default class ImplicitTarget extends BaseTarget {
   isRaw = true;
   hasExplicitScopeType = false;
   isImplicit = true;
+  isToken = false;
 
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;

--- a/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/PlainTarget.ts
@@ -1,4 +1,8 @@
-import BaseTarget from "./BaseTarget";
+import BaseTarget, { CommonTargetParameters } from "./BaseTarget";
+
+interface PlainTargetParameters extends CommonTargetParameters {
+  readonly isToken?: boolean;
+}
 
 /**
  * A target that has no leading or trailing delimiters so it's removal range
@@ -6,6 +10,11 @@ import BaseTarget from "./BaseTarget";
  */
 export default class PlainTarget extends BaseTarget {
   insertionDelimiter = "";
+
+  constructor(parameters: PlainTargetParameters) {
+    super(parameters);
+    this.isToken = parameters.isToken ?? true;
+  }
 
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;

--- a/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/RawSelectionTarget.ts
@@ -8,6 +8,7 @@ import BaseTarget from "./BaseTarget";
 export default class RawSelectionTarget extends BaseTarget {
   insertionDelimiter = "";
   isRaw = true;
+  isToken = false;
 
   getLeadingDelimiterTarget = () => undefined;
   getTrailingDelimiterTarget = () => undefined;

--- a/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/SubTokenWordTarget.ts
@@ -13,6 +13,7 @@ export default class SubTokenWordTarget extends BaseTarget {
   private leadingDelimiterRange_?: Range;
   private trailingDelimiterRange_?: Range;
   insertionDelimiter: string;
+  isToken = false;
 
   constructor(parameters: SubTokenTargetParameters) {
     super(parameters);

--- a/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
+++ b/packages/cursorless-engine/src/processTargets/targets/UntypedTarget.ts
@@ -10,6 +10,7 @@ import {
 
 interface UntypedTargetParameters extends CommonTargetParameters {
   readonly hasExplicitRange: boolean;
+  readonly isToken?: boolean;
 }
 
 /**
@@ -24,6 +25,7 @@ export default class UntypedTarget extends BaseTarget {
   constructor(parameters: UntypedTargetParameters) {
     super(parameters);
     this.hasExplicitRange = parameters.hasExplicitRange;
+    this.isToken = parameters.isToken ?? true;
   }
 
   getLeadingDelimiterTarget(): Target | undefined {

--- a/packages/cursorless-engine/src/typings/target.types.ts
+++ b/packages/cursorless-engine/src/typings/target.types.ts
@@ -44,6 +44,9 @@ export interface Target {
   /** If true this target should be treated as a line */
   readonly isLine: boolean;
 
+  /** If true this target should be treated as a token */
+  readonly isToken: boolean;
+
   /**
    * If `true`, then this target has an explicit scope type, and so should never
    * be automatically expanded to a containing scope.


### PR DESCRIPTION
- Primarily useful for https://github.com/cursorless-dev/cursorless/pull/1497
- Depends on https://github.com/cursorless-dev/cursorless/pull/1495

## Checklist

- [ ] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [ ] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [ ] I have not broken the cheatsheet
