### PR TITLE
Always reset stored targets when running tests

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/recorded.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/recorded.vscode.test.ts
@@ -89,21 +89,15 @@ async function runTest(file: string, spyIde: SpyIDE) {
 
   editor.selections = fixture.initialState.selections.map(createSelection);
 
-  if (fixture.initialState.thatMark) {
-    setStoredTarget(editor, "that", fixture.initialState.thatMark);
-  }
+  setStoredTarget(editor, "that", fixture.initialState.thatMark);
 
-  if (fixture.initialState.sourceMark) {
-    setStoredTarget(editor, "source", fixture.initialState.sourceMark);
-  }
+  setStoredTarget(editor, "source", fixture.initialState.sourceMark);
 
-  if (fixture.initialState.instanceReferenceMark) {
-    setStoredTarget(
-      editor,
-      "instanceReference",
-      fixture.initialState.instanceReferenceMark,
-    );
-  }
+  setStoredTarget(
+    editor,
+    "instanceReference",
+    fixture.initialState.instanceReferenceMark,
+  );
 
   if (fixture.initialState.clipboard) {
     vscode.env.clipboard.writeText(fixture.initialState.clipboard);


### PR DESCRIPTION
Stored targets were not updated if the fixture contained none. This means that stored targets from previous fixture was still active. In one case it made a instance tests incorrectly use the from target set by the previous recorded test and the instance test failed as a result.

## Checklist

- [-] I have added [tests](https://www.cursorless.org/docs/contributing/test-case-recorder/)
- [-] I have updated the [docs](https://github.com/cursorless-dev/cursorless/tree/main/docs) and [cheatsheet](https://github.com/cursorless-dev/cursorless/tree/main/cursorless-talon/src/cheatsheet)
- [-] I have not broken the cheatsheet
