### PR TITLE
cursorless-talon: Create PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/cursorless-talon/.github/PULL_REQUEST_TEMPLATE.md
+++ b/cursorless-talon/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,1 @@
+Please file pull requests to the cursorless-talon subdirectory in the https://github.com/cursorless-dev/cursorless repo


### PR DESCRIPTION
Hopefully prevent folks from sending PRs to <https://github.com/cursorless-dev/cursorless-talon>, which can then get merged and result in this mess:

```console
> git pull --ff-only
remote: Enumerating objects: 33, done.
remote: Counting objects: 100% (30/30), done.
remote: Compressing objects: 100% (11/11), done.
remote: Total 33 (delta 21), reused 28 (delta 19), pack-reused 3 (from 1)
Receiving objects: 100% (33/33), 10.82 KiB | 10.82 MiB/s, done.
Resolving deltas: 100% (21/21), completed with 11 local objects.
From https://github.com/cursorless-dev/cursorless-talon
   d8a602ee2d4b..b6e796b83d62  main       -> origin/main
hint: Diverging branches can't be fast-forwarded, you need to either:
hint:
hint:   git merge --no-ff
hint:
hint: or:
hint:
hint:   git rebase
hint:
hint: Disable this message with "git config advice.diverging false"
fatal: Not possible to fast-forward, aborting.
```