### PR TITLE
Support VS Code forks in install scripts

### DIFF
--- a/packages/cursorless-vscode/scripts/install-from-pr.sh
+++ b/packages/cursorless-vscode/scripts/install-from-pr.sh
@@ -16,9 +16,14 @@ if ! command -v gh &>/dev/null; then
   exit 1
 fi
 
-# Ensure VSCode 'code' command is installed
-if ! command -v code &>/dev/null; then
-  echo "VSCode 'code' command not found; see https://code.visualstudio.com/docs/editor/command-line#_launching-from-command-line"
+# Use CURSORLESS_VSCODE_COMMAND if set, otherwise default to 'code'
+vscode_command="${CURSORLESS_VSCODE_COMMAND:-code}"
+
+# Ensure VSCode command is installed
+if ! command -v "$vscode_command" &>/dev/null; then
+  echo "VSCode command '$vscode_command' not found"
+  echo "Install VS Code or set CURSORLESS_VSCODE_COMMAND to your VS Code binary (e.g., 'codium', 'cursor')"
+  echo "See: https://code.visualstudio.com/docs/editor/command-line"
   exit 1
 fi
 
@@ -47,10 +52,10 @@ trap finish EXIT
 gh run download "$check_number" --repo "$repo" --name vsix --dir "$tmpdir"
 
 # 4. Uninstall production cursorless
-code --uninstall-extension pokey.cursorless || echo "Cursorless not currently installed"
+"$vscode_command" --uninstall-extension pokey.cursorless || echo "Cursorless not currently installed"
 
 # 5. Install downloaded extension
-code --install-extension "$tmpdir/cursorless-development.vsix" --force
+"$vscode_command" --install-extension "$tmpdir/cursorless-development.vsix" --force
 
 echo -e "\e[1;32mPlease restart VSCode\e[0m"
 echo "To uninstall and revert to production Cursorless, run the adjacent uninstall-local.sh"

--- a/packages/cursorless-vscode/scripts/install-local.sh
+++ b/packages/cursorless-vscode/scripts/install-local.sh
@@ -1,5 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
+
+# Use CURSORLESS_VSCODE_COMMAND if set, otherwise default to 'code'
+vscode_command="${CURSORLESS_VSCODE_COMMAND:-code}"
+
+# Ensure VSCode command is installed
+if ! command -v "$vscode_command" &>/dev/null; then
+  echo "VSCode command '$vscode_command' not found"
+  echo "Install VS Code or set CURSORLESS_VSCODE_COMMAND to your VS Code binary (e.g., 'codium', 'cursor')"
+  echo "See: https://code.visualstudio.com/docs/editor/command-line"
+  exit 1
+fi
+
 # Bundles and installs a local version of Cursorless, uninstalling production
 # Cursorless first and using a special extension id to break update chain
 
@@ -14,10 +26,10 @@ cd dist
 vsce package -o ../bundle.vsix
 
 # 3. Uninstall production cursorless
-code --uninstall-extension pokey.cursorless || echo "Cursorless not currently installed"
+"$vscode_command" --uninstall-extension pokey.cursorless || echo "Cursorless not currently installed"
 
 # 4. Install local Cursorless
-code --install-extension ../bundle.vsix --force
+"$vscode_command" --install-extension ../bundle.vsix --force
 
 echo -e "\e[1;32mPlease restart VSCode\e[0m"
 echo "To uninstall and revert to production Cursorless, run the adjacent uninstall-local.sh"

--- a/packages/cursorless-vscode/scripts/uninstall-local.sh
+++ b/packages/cursorless-vscode/scripts/uninstall-local.sh
@@ -1,13 +1,24 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+# Use CURSORLESS_VSCODE_COMMAND if set, otherwise default to 'code'
+vscode_command="${CURSORLESS_VSCODE_COMMAND:-code}"
+
+# Ensure VSCode command is installed
+if ! command -v "$vscode_command" &>/dev/null; then
+  echo "VSCode command '$vscode_command' not found"
+  echo "Install VS Code or set CURSORLESS_VSCODE_COMMAND to your VS Code binary (e.g., 'codium', 'cursor')"
+  echo "See: https://code.visualstudio.com/docs/editor/command-line"
+  exit 1
+fi
+
 # Switch back to production Cursorless extension locally after having run
 # ./install-local.sh
 
 # 1. Uninstall local cursorless
-code --uninstall-extension pokey.cursorless-development || echo "Cursorless development version not currently installed"
+"$vscode_command" --uninstall-extension pokey.cursorless-development || echo "Cursorless development version not currently installed"
 
 # 2. Install production Cursorless
-code --install-extension pokey.cursorless
+"$vscode_command" --install-extension pokey.cursorless
 
 echo -e "\e[1;32mPlease restart VSCode\e[0m"


### PR DESCRIPTION
Add CURSORLESS_VSCODE_COMMAND environment variable to allow using VS Code forks like VSCodium, Cursor, etc. in the install scripts.

- install-from-pr.sh: Use env var with fallback to 'code'
- install-local.sh: Use env var with fallback to 'code'  
- uninstall-local.sh: Use env var with fallback to 'code'
- Updated error messages with helpful installation guidance
- Maintains backward compatibility

Closes #3093