### PR TITLE
Add skipDuplicate to Open VSX publish step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -47,6 +47,7 @@ jobs:
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           packagePath: packages/cursorless-vscode/dist
+          skipDuplicate: true
 
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2


### PR DESCRIPTION
Makes it possible to rerun the deploy workflow when the vscode market place failed previously  