### PR TITLE
Separate VSCode publish jobs

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  publish-extension:
+  publish-to-open-vsx:
     runs-on: ubuntu-latest
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
     environment: production
@@ -47,14 +47,37 @@ jobs:
         with:
           pat: ${{ secrets.OPEN_VSX_TOKEN }}
           packagePath: packages/cursorless-vscode/dist
-          skipDuplicate: true
+
+      - name: Upload VSIX
+        uses: actions/upload-artifact@v4
+        with:
+          name: vscode-extension
+          path: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          retention-days: 1
+
+  publish-to-vs-marketplace:
+    runs-on: ubuntu-latest
+    needs: publish-to-open-vsx
+    environment: production
+
+    steps:
+      - name: Download VSIX
+        uses: actions/download-artifact@v4
+        with:
+          name: vscode-extension
+
+      - name: Get VSIX file path
+        id: getPath
+        run: |
+          VSIX_FILE=$(find . -maxdepth 1 -name "*.vsix" -type f)
+          echo "vsixPath=$VSIX_FILE" >> $GITHUB_OUTPUT
 
       - name: Publish to Visual Studio Marketplace
         uses: HaaLeo/publish-vscode-extension@v2
         with:
           pat: ${{ secrets.VS_MARKETPLACE_TOKEN }}
           registryUrl: https://marketplace.visualstudio.com
-          extensionFile: ${{ steps.publishToOpenVSX.outputs.vsixPath }}
+          extensionFile: ${{ steps.getPath.outputs.vsixPath }}
 
   publish-neovim-extension:
     runs-on: ubuntu-latest
@@ -116,7 +139,7 @@ jobs:
   push-cursorless-talon:
     name: Push cursorless-talon subrepo
     runs-on: ubuntu-latest
-    needs: publish-extension
+    needs: [publish-to-vs-marketplace, publish-neovim-extension]
     environment: production
 
     steps:


### PR DESCRIPTION
Implements the suggestion from #3104 to separate the publish jobs.

- Split VSCode publish into two separate jobs (Open VSX and VS Marketplace)
- Ensures the same VSIX file is published to both registries
- Build and Open VSX publish happen together, VS Marketplace publishes sequentially to the same VSIX
- Allows independent reruns of each marketplace publish job
- Removed skipDuplicate as it's no longer needed with separate jobs

Amp-Thread-ID: https://ampcode.com/threads/T-c5112243-7633-492f-911d-5c3e5998c847