### PR TITLE
Re-enable latex tests for vscode versions >= 1.107.0

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/shouldSkipTest.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/shouldSkipTest.ts
@@ -5,7 +5,8 @@ import * as vscode from "vscode";
  * FIXME: On newer vscode versions some Tree sitter parser throws memory errors
  * https://github.com/cursorless-dev/cursorless/issues/2879
  */
-const isVersionProblematic = semver.lt(vscode.version, "1.107.0") && semver.gte(vscode.version, "1.98.0");
+const isVersionProblematic =
+  semver.lt(vscode.version, "1.107.0") && semver.gte(vscode.version, "1.98.0");
 
 export function shouldSkipRecordedTest(name: string): boolean {
   return isVersionProblematic && name.startsWith("recorded/languages/latex/");


### PR DESCRIPTION
Vscode issue https://github.Com/microsoft/vscode/issues/243747 is closed and released in vscode version `1.107.0`.

Latex is now supported on parse tree extension `0.48.0` 
https://github.com/cursorless-dev/vscode-parse-tree/pull/124

Fixes #2879