### PR TITLE
Migrate prettier config to javascript

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,0 @@
-{
-  "trailingComma": "all",
-  "plugins": ["prettier-plugin-tailwindcss"]
-}

--- a/eslint.config.mts
+++ b/eslint.config.mts
@@ -137,6 +137,7 @@ const disabledTypeCheckConfig: ConfigWithExtends = {
     "**/docusaurus.config.mts",
     "**/eslint.config.mts",
     "**/mdx-components.tsx",
+    "prettier.config.cjs",
     "typings/**",
     "**/*.js",
     "**/*.mjs",

--- a/prettier.config.cjs
+++ b/prettier.config.cjs
@@ -1,0 +1,8 @@
+/* global module, require */
+
+/** @type {import("prettier").Config} */
+module.exports = {
+  trailingComma: "all",
+
+  plugins: [require.resolve("prettier-plugin-tailwindcss")],
+};


### PR DESCRIPTION
Newer versions of prettier works badly with vscode prettier extension when using a json config file.