### PR TITLE
Fix bug with multiple cursor performance tests

### DIFF
--- a/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
+++ b/packages/cursorless-vscode-e2e/src/suite/performance.vscode.test.ts
@@ -90,11 +90,10 @@ suite("Performance", async function () {
   }
 
   test(
-    "Select surroundingPair with multiple cursors",
+    "Select collectionKey with multiple cursors",
     asyncSafety(() =>
       selectWithMultipleCursors(largeThresholdMs, {
-        type: "surroundingPair",
-        delimiter: "any",
+        type: "collectionKey",
       }),
     ),
   );
@@ -104,6 +103,16 @@ suite("Performance", async function () {
     asyncSafety(() =>
       selectWithMultipleCursors(largeThresholdMs, {
         type: "collectionItem",
+      }),
+    ),
+  );
+
+  test(
+    "Select surroundingPair.any with multiple cursors",
+    asyncSafety(() =>
+      selectWithMultipleCursors(largeThresholdMs, {
+        type: "surroundingPair",
+        delimiter: "any",
       }),
     ),
   );
@@ -120,27 +129,29 @@ function removeToken(thresholdMs: number) {
 }
 
 function selectWithMultipleCursors(thresholdMs: number, scopeType: ScopeType) {
-  return testPerformanceCallback(
-    thresholdMs,
-    () => {
-      return runCursorlessAction({
-        name: "setSelection",
-        target: {
-          type: "primitive",
-          modifiers: [getModifier(scopeType)],
-        },
-      });
-    },
-    () => {
-      return runCursorlessAction({
-        name: "setSelectionBefore",
-        target: {
-          type: "primitive",
-          modifiers: [getModifier({ type: "collectionItem" }, "every")],
-        },
-      });
-    },
-  );
+  const beforeCallback = async (editor: vscode.TextEditor) => {
+    await runCursorlessAction({
+      name: "setSelectionBefore",
+      target: {
+        type: "primitive",
+        modifiers: [getModifier({ type: "collectionItem" }, "every")],
+      },
+    });
+
+    assert.equal(editor.selections.length, 100, "Expected 100 cursors");
+  };
+
+  const callback = () => {
+    return runCursorlessAction({
+      name: "setSelection",
+      target: {
+        type: "primitive",
+        modifiers: [getModifier(scopeType)],
+      },
+    });
+  };
+
+  return testPerformanceCallback(thresholdMs, callback, beforeCallback);
 }
 
 function selectScopeType(
@@ -166,7 +177,7 @@ function testPerformance(thresholdMs: number, action: ActionDescriptor) {
 async function testPerformanceCallback(
   thresholdMs: number,
   callback: () => Promise<unknown>,
-  beforeCallback?: () => Promise<unknown>,
+  beforeCallback?: (editor: vscode.TextEditor) => Promise<unknown>,
 ) {
   const editor = await openNewEditor(testData, { languageId: "json" });
   // This is the position of the last json key in the document
@@ -176,7 +187,7 @@ async function testPerformanceCallback(
   editor.revealRange(selection);
 
   if (beforeCallback != null) {
-    await beforeCallback();
+    await beforeCallback(editor);
   }
 
   const start = performance.now();


### PR DESCRIPTION
The two callback arguments were in the wrong order. The result of this was that we first selected a single scope and then all of them when the purpose of the tests was to first set multiple selections and then take a single scope for each of them.