### PR TITLE
 Replace Array.sort and Array.reverse with Array.toSorted and Array.toReversed

### DIFF
--- a/oxlint.config.mts
+++ b/oxlint.config.mts
@@ -1,15 +1,7 @@
 import type { OxlintConfig } from "oxlint";
 import { defineConfig } from "oxlint";
 
-// These rules should probably be re-enabled eventually
-const temporarilyDisabledRules = [
-  // Requires es2023
-  "unicorn/no-array-sort",
-  "unicorn/no-array-reverse",
-];
-
 const disabledRules = [
-  ...temporarilyDisabledRules,
   "eslint/arrow-body-style",
   "eslint/capitalized-comments",
   "eslint/class-methods-use-this",

--- a/packages/app-vscode/src/ScopeTreeProvider.ts
+++ b/packages/app-vscode/src/ScopeTreeProvider.ts
@@ -202,7 +202,7 @@ export class ScopeTreeProvider implements TreeDataProvider<MyTreeItem> {
             getContainmentIcon?.(supportLevel.scopeType),
           ),
       )
-      .sort((a, b) => {
+      .toSorted((a, b) => {
         if (
           a.scopeTypeInfo.spokenForm.type !== b.scopeTypeInfo.spokenForm.type
         ) {

--- a/packages/app-vscode/src/ScopeTreeProvider.ts
+++ b/packages/app-vscode/src/ScopeTreeProvider.ts
@@ -182,7 +182,7 @@ export class ScopeTreeProvider implements TreeDataProvider<MyTreeItem> {
       };
     })();
 
-    return this.supportLevels
+    const supportLevels = this.supportLevels
       .filter(
         (supportLevel) =>
           supportLevel.support === scopeSupport &&
@@ -201,26 +201,11 @@ export class ScopeTreeProvider implements TreeDataProvider<MyTreeItem> {
             isEqual(supportLevel.scopeType, this.scopeVisualizer.scopeType),
             getContainmentIcon?.(supportLevel.scopeType),
           ),
-      )
-      .toSorted((a, b) => {
-        if (
-          a.scopeTypeInfo.spokenForm.type !== b.scopeTypeInfo.spokenForm.type
-        ) {
-          // Scopes with no spoken form are sorted to the bottom
-          return a.scopeTypeInfo.spokenForm.type === "error" ? 1 : -1;
-        }
+      );
 
-        if (
-          a.scopeTypeInfo.isLanguageSpecific !==
-          b.scopeTypeInfo.isLanguageSpecific
-        ) {
-          // Then language-specific scopes are sorted to the top
-          return a.scopeTypeInfo.isLanguageSpecific ? -1 : 1;
-        }
+    supportLevels.sort(compareScopeTypes);
 
-        // Then alphabetical by label
-        return a.label.label.localeCompare(b.label.label);
-      });
+    return supportLevels;
   }
 
   private getContainmentIcon(
@@ -253,6 +238,26 @@ export class ScopeTreeProvider implements TreeDataProvider<MyTreeItem> {
   dispose() {
     this.visibleDisposable?.dispose();
   }
+}
+
+function compareScopeTypes(
+  a: ScopeSupportTreeItem,
+  b: ScopeSupportTreeItem,
+): number {
+  if (a.scopeTypeInfo.spokenForm.type !== b.scopeTypeInfo.spokenForm.type) {
+    // Scopes with no spoken form are sorted to the bottom
+    return a.scopeTypeInfo.spokenForm.type === "error" ? 1 : -1;
+  }
+
+  if (
+    a.scopeTypeInfo.isLanguageSpecific !== b.scopeTypeInfo.isLanguageSpecific
+  ) {
+    // Then language-specific scopes are sorted to the top
+    return a.scopeTypeInfo.isLanguageSpecific ? -1 : 1;
+  }
+
+  // Then alphabetical by label
+  return a.label.label.localeCompare(b.label.label);
 }
 
 function getSupportCategories(): SupportCategoryTreeItem[] {

--- a/packages/app-vscode/src/keyboard/KeyboardCommandsModal.ts
+++ b/packages/app-vscode/src/keyboard/KeyboardCommandsModal.ts
@@ -90,7 +90,7 @@ export class KeyboardCommandsModal {
     const acceptableTokenTypeInfos = getAcceptableTokenTypes(this.parser);
     // FIXME: Here's where we'd update sidebar
     const acceptableTokenTypes = sortedUniq(
-      acceptableTokenTypeInfos.map(({ type }) => type).sort(),
+      acceptableTokenTypeInfos.map(({ type }) => type).toSorted(),
     );
     let layer = this.layerCache.get(acceptableTokenTypes);
     if (layer == null) {

--- a/packages/app-vscode/src/keyboard/KeyboardHandler.ts
+++ b/packages/app-vscode/src/keyboard/KeyboardHandler.ts
@@ -152,7 +152,9 @@ export class KeyboardHandler {
         // one. Eg if you're in the middle of typing a command and we turn off
         // the modal mode, we want to cancel the command
         if (index !== -1) {
-          const listenersToCancel = this.listeners.slice(index + 1).reverse();
+          const listenersToCancel = this.listeners
+            .slice(index + 1)
+            .toReversed();
           for (const entry of listenersToCancel) {
             entry.listener.handleCancelled();
           }

--- a/packages/app-vscode/src/keyboard/buildSuffixTrie.test.ts
+++ b/packages/app-vscode/src/keyboard/buildSuffixTrie.test.ts
@@ -125,7 +125,7 @@ suite("buildSuffixTrie", () => {
       const { trie, conflicts } = buildSuffixTrie<string>(
         input.map((key) => [key, key]),
       );
-      const chars = uniq(input.flatMap((key) => key.split(""))).sort();
+      const chars = uniq(input.flatMap((key) => key.split(""))).toSorted();
       const actual = uniqWith(
         sortEntries(chars.flatMap((char) => trie.search(char))),
         isEqual,

--- a/packages/app-vscode/src/keyboard/grammar/getAcceptableTokenTypes.test.ts
+++ b/packages/app-vscode/src/keyboard/grammar/getAcceptableTokenTypes.test.ts
@@ -133,6 +133,7 @@ const testCases: TestCase[] = [
 
 suite("keyboard.getAcceptableTokenTypes", () => {
   let parser: nearley.Parser;
+
   setup(() => {
     parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
   });

--- a/packages/app-vscode/src/keyboard/grammar/grammar.test.ts
+++ b/packages/app-vscode/src/keyboard/grammar/grammar.test.ts
@@ -180,6 +180,7 @@ const testCases: TestCase[] = [
 
 suite("keyboard grammar", () => {
   let parser: nearley.Parser;
+
   setup(() => {
     parser = new nearley.Parser(nearley.Grammar.fromCompiled(grammar));
   });

--- a/packages/app-web-docs/src/docs/components/ScopeVisualizer.tsx
+++ b/packages/app-web-docs/src/docs/components/ScopeVisualizer.tsx
@@ -315,7 +315,7 @@ function getScopeFixtures(
   }
 
   const result: Scopes = { public: [], internal: [] };
-  const sortedScopes = Object.values(scopeMap).sort(nameComparator);
+  const sortedScopes = Object.values(scopeMap).toSorted(nameComparator);
 
   for (const scope of sortedScopes) {
     scope.facets.sort(facetComparator);

--- a/packages/app-web-docs/src/docs/components/flattenHighlights.ts
+++ b/packages/app-web-docs/src/docs/components/flattenHighlights.ts
@@ -53,7 +53,7 @@ function getUniquePositions(highlights: Highlight[]): Position[] {
   const result: Position[] = [];
   const positions = highlights
     .flatMap((h) => [h.range.start, h.range.end])
-    .sort((a, b) =>
+    .toSorted((a, b) =>
       a.line === b.line ? a.character - b.character : a.line - b.line,
     );
   for (let i = 0; i < positions.length; i++) {

--- a/packages/app-web-docs/src/docs/contributing/MissingLanguageScopes.tsx
+++ b/packages/app-web-docs/src/docs/contributing/MissingLanguageScopes.tsx
@@ -10,7 +10,7 @@ import {
 
 export function MissingLanguageScopes(): React.JSX.Element {
   const [showPrivate, setShowPrivate] = useState(false);
-  const languageIds = Object.keys(languageScopeSupport).sort();
+  const languageIds = Object.keys(languageScopeSupport).toSorted();
 
   return (
     <>
@@ -48,10 +48,10 @@ function Language({
     .filter(
       (facet) => scopeSupport[facet] === ScopeSupportFacetLevel.unsupported,
     )
-    .sort();
+    .toSorted();
   let unspecifiedFacets = scopeSupportFacets
     .filter((facet) => scopeSupport[facet] == null)
-    .sort();
+    .toSorted();
 
   if (!showPrivate) {
     unsupportedFacets = unsupportedFacets.filter((f) => !isPrivate(f));

--- a/packages/lib-common/src/ide/inMemoryTextEditor/performEdits.ts
+++ b/packages/lib-common/src/ide/inMemoryTextEditor/performEdits.ts
@@ -42,7 +42,7 @@ function createChangeEvents(
    */
   const sortedEdits = edits
     .map((edit, index) => ({ edit, index }))
-    .sort((a, b) => {
+    .toSorted((a, b) => {
       // Edits starting at the same position are sorted in reverse given order.
       if (a.edit.range.start.isEqual(b.edit.range.start)) {
         return b.index - a.index;

--- a/packages/lib-common/src/ide/inMemoryTextEditor/performEdits.ts
+++ b/packages/lib-common/src/ide/inMemoryTextEditor/performEdits.ts
@@ -42,7 +42,8 @@ function createChangeEvents(
    */
   const sortedEdits = edits
     .map((edit, index) => ({ edit, index }))
-    .toSorted((a, b) => {
+    // oxlint-disable-next-line unicorn/no-array-sort
+    .sort((a, b) => {
       // Edits starting at the same position are sorted in reverse given order.
       if (a.edit.range.start.isEqual(b.edit.range.start)) {
         return b.index - a.index;

--- a/packages/lib-engine/src/actions/Sort.ts
+++ b/packages/lib-engine/src/actions/Sort.ts
@@ -25,9 +25,9 @@ abstract class SortBase implements SimpleAction {
     }
 
     // First sort target by document order
-    const sortedTargets = targets
-      .slice()
-      .sort((a, b) => a.contentRange.start.compareTo(b.contentRange.start));
+    const sortedTargets = targets.toSorted((a, b) =>
+      a.contentRange.start.compareTo(b.contentRange.start),
+    );
 
     const { returnValue: unsortedTexts } = await this.actions.getText.run(
       sortedTargets,
@@ -49,7 +49,7 @@ abstract class SortBase implements SimpleAction {
 
 export class Sort extends SortBase {
   protected sortTexts(texts: string[]) {
-    return texts.sort((a, b) =>
+    return texts.toSorted((a, b) =>
       a.localeCompare(b, undefined, {
         numeric: true,
         caseFirst: "upper",
@@ -60,7 +60,7 @@ export class Sort extends SortBase {
 
 export class Reverse extends SortBase {
   protected sortTexts(texts: string[]) {
-    return texts.reverse();
+    return texts.toReversed();
   }
 }
 

--- a/packages/lib-engine/src/core/getPreferredSnippet.ts
+++ b/packages/lib-engine/src/core/getPreferredSnippet.ts
@@ -47,7 +47,7 @@ function getUniqueLanguagesString(snippets: CustomInsertSnippetArg[]): string {
   const languages = new Set(
     snippets.flatMap((snippet) => snippet.languages ?? []),
   );
-  return Array.from(languages).sort().join(", ");
+  return Array.from(languages).toSorted().join(", ");
 }
 
 function tryToFindPreferredSnippet<

--- a/packages/lib-engine/src/core/handleHoistedModifiers.ts
+++ b/packages/lib-engine/src/core/handleHoistedModifiers.ts
@@ -56,7 +56,7 @@ export function handleHoistedModifiers(
   // modifier to the range owns the range. For example if you say "every line
   // every funk air past bat", the "every line" owns the range, and the "every
   // funk" is applied to the output.
-  for (const [modifier, idx] of indexedModifiers.reverse()) {
+  for (const [modifier, idx] of indexedModifiers.toReversed()) {
     for (const hoistedModifierType of hoistedModifierTypes) {
       const acceptanceInfo = hoistedModifierType.accept(modifier);
       if (acceptanceInfo.accepted) {

--- a/packages/lib-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
+++ b/packages/lib-engine/src/languages/TreeSitterQuery/checkCaptureStartEnd.ts
@@ -31,12 +31,12 @@ export function checkCaptureStartEnd(
   const lastStart = captures
     .filter(({ name }) => name.endsWith(".start"))
     .map(({ range: { end } }) => end)
-    .sort((a, b) => a.compareTo(b))
+    .toSorted((a, b) => a.compareTo(b))
     .at(-1);
   const firstEnd = captures
     .filter(({ name }) => name.endsWith(".end"))
     .map(({ range: { start } }) => start)
-    .sort((a, b) => a.compareTo(b))
+    .toSorted((a, b) => a.compareTo(b))
     .at(0);
   if (lastStart != null && firstEnd != null) {
     if (lastStart.isAfter(firstEnd)) {

--- a/packages/lib-engine/src/processTargets/TargetPipelineRunner.ts
+++ b/packages/lib-engine/src/processTargets/TargetPipelineRunner.ts
@@ -300,7 +300,7 @@ export function getModifierStagesFromTargetModifiers(
 ) {
   // Reverse target modifiers because they are returned in reverse order from
   // the api, to match the order in which they are spoken.
-  return targetModifiers.map(modifierStageFactory.create).reverse();
+  return targetModifiers.map(modifierStageFactory.create).toReversed();
 }
 
 /** Run all targets through the modifier stages */

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/BaseScopeHandler.test.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/BaseScopeHandler.test.ts
@@ -133,8 +133,8 @@ suite("BaseScopeHandler", () => {
       }));
 
       assert.deepEqual(
-        [...inputScopes]
-          .sort((a, b) =>
+        inputScopes
+          .toSorted((a, b) =>
             compareTargetScopes(testCase.direction, position, a, b),
           )
           .map(fromScope),

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellApiScopeHandler.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/NotebookCellApiScopeHandler.ts
@@ -68,7 +68,7 @@ function getNotebookCells(
   ) {
     return direction === "forward"
       ? notebook.cells.slice(cell.index + 1)
-      : notebook.cells.slice(0, cell.index).reverse();
+      : notebook.cells.slice(0, cell.index).toReversed();
   }
 
   // Every scope
@@ -81,7 +81,7 @@ function getNotebookCells(
 
   return direction === "forward"
     ? notebook.cells.slice(cell.index)
-    : notebook.cells.slice(0, cell.index + 1).reverse();
+    : notebook.cells.slice(0, cell.index + 1).toReversed();
 }
 
 function getNotebook(ide: IDE, editor: TextEditor) {

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SentenceScopeHandler/SentenceScopeHandler.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SentenceScopeHandler/SentenceScopeHandler.ts
@@ -42,6 +42,7 @@ export class SentenceScopeHandler extends NestedScopeHandler {
 
     return direction === "forward"
       ? imap(sentences, sentenceToScope)
-      : Array.from(sentences, sentenceToScope).toReversed();
+      : // oxlint-disable-next-line unicorn/no-array-sort
+        Array.from(sentences, sentenceToScope).sort();
   }
 }

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SentenceScopeHandler/SentenceScopeHandler.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SentenceScopeHandler/SentenceScopeHandler.ts
@@ -42,6 +42,6 @@ export class SentenceScopeHandler extends NestedScopeHandler {
 
     return direction === "forward"
       ? imap(sentences, sentenceToScope)
-      : Array.from(sentences, sentenceToScope).reverse();
+      : Array.from(sentences, sentenceToScope).toReversed();
   }
 }

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SentenceScopeHandler/SentenceScopeHandler.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SentenceScopeHandler/SentenceScopeHandler.ts
@@ -42,7 +42,7 @@ export class SentenceScopeHandler extends NestedScopeHandler {
 
     return direction === "forward"
       ? imap(sentences, sentenceToScope)
-      : // oxlint-disable-next-line unicorn/no-array-sort
-        Array.from(sentences, sentenceToScope).sort();
+      : // oxlint-disable-next-line unicorn/no-array-reverse
+        Array.from(sentences, sentenceToScope).reverse();
   }
 }

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/SurroundingPairScopeHandler.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/SurroundingPairScopeHandler.ts
@@ -73,7 +73,7 @@ export class SurroundingPairScopeHandler extends BaseScopeHandler {
           this.scopeType.requireStrongContainment ?? false,
         ),
       )
-      .sort((a, b) => compareTargetScopes(direction, position, a, b));
+      .toSorted((a, b) => compareTargetScopes(direction, position, a, b));
   }
 }
 

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/SurroundingPairScopeHandler.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/SurroundingPairScopeHandler.ts
@@ -73,7 +73,8 @@ export class SurroundingPairScopeHandler extends BaseScopeHandler {
           this.scopeType.requireStrongContainment ?? false,
         ),
       )
-      .toSorted((a, b) => compareTargetScopes(direction, position, a, b));
+      // oxlint-disable-next-line unicorn/no-array-sort
+      .sort((a, b) => compareTargetScopes(direction, position, a, b));
   }
 }
 

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getDelimiterOccurrences.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getDelimiterOccurrences.ts
@@ -92,5 +92,6 @@ function getSortedCaptures(items?: QueryCapture[]): QueryCapture[] {
   if (items == null) {
     return [];
   }
-  return items.toSorted((a, b) => a.range.start.compareTo(b.range.start));
+  items.sort((a, b) => a.range.start.compareTo(b.range.start));
+  return items;
 }

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getDelimiterOccurrences.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/SurroundingPairScopeHandler/getDelimiterOccurrences.ts
@@ -92,5 +92,5 @@ function getSortedCaptures(items?: QueryCapture[]): QueryCapture[] {
   if (items == null) {
     return [];
   }
-  return items.sort((a, b) => a.range.start.compareTo(b.range.start));
+  return items.toSorted((a, b) => a.range.start.compareTo(b.range.start));
 }

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/BaseTreeSitterScopeHandler.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/BaseTreeSitterScopeHandler.ts
@@ -46,7 +46,7 @@ export abstract class BaseTreeSitterScopeHandler extends BaseScopeHandler {
       .matches(document, start, end)
       .map((match) => this.matchToScope(editor, match, isEveryScope))
       .filter((scope): scope is ExtendedTargetScope => scope != null)
-      .sort((a, b) => compareTargetScopes(direction, position, a, b));
+      .toSorted((a, b) => compareTargetScopes(direction, position, a, b));
 
     // Merge scopes that have the same domain into a single scope with multiple
     // targets

--- a/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/BaseTreeSitterScopeHandler.ts
+++ b/packages/lib-engine/src/processTargets/modifiers/scopeHandlers/TreeSitterScopeHandler/BaseTreeSitterScopeHandler.ts
@@ -46,7 +46,8 @@ export abstract class BaseTreeSitterScopeHandler extends BaseScopeHandler {
       .matches(document, start, end)
       .map((match) => this.matchToScope(editor, match, isEveryScope))
       .filter((scope): scope is ExtendedTargetScope => scope != null)
-      .toSorted((a, b) => compareTargetScopes(direction, position, a, b));
+      // oxlint-disable-next-line unicorn/no-array-sort
+      .sort((a, b) => compareTargetScopes(direction, position, a, b));
 
     // Merge scopes that have the same domain into a single scope with multiple
     // targets

--- a/packages/lib-engine/src/scopeProviders/ScopeSupportWatcher.ts
+++ b/packages/lib-engine/src/scopeProviders/ScopeSupportWatcher.ts
@@ -110,7 +110,6 @@ export class ScopeSupportWatcher {
 
     const scopeTypeInfos = this.scopeInfoProvider.getScopeTypeInfos();
 
-    // oxlint-disable-next-line oxc/no-map-spread
     return scopeTypeInfos.map((scopeTypeInfo) => ({
       ...scopeTypeInfo,
       support: getScopeTypeSupport(scopeTypeInfo.scopeType),

--- a/packages/lib-engine/src/scripts/transformRecordedTests/checkMarks.ts
+++ b/packages/lib-engine/src/scripts/transformRecordedTests/checkMarks.ts
@@ -29,8 +29,8 @@ export function checkMarks(originalFixture: TestCaseFixtureLegacy): undefined {
   const actualMarks = Object.keys(originalFixture.initialState.marks ?? {});
 
   assert.deepEqual(
-    uniq(actualMarks.map(normalizeGraphemes)).sort(),
-    uniq(expectedMarks.map(normalizeGraphemes)).sort(),
+    uniq(actualMarks.map(normalizeGraphemes)).toSorted(),
+    uniq(expectedMarks.map(normalizeGraphemes)).toSorted(),
   );
 
   return undefined;

--- a/packages/lib-engine/src/test/scopes.test.ts
+++ b/packages/lib-engine/src/test/scopes.test.ts
@@ -43,7 +43,7 @@ suite("Scope test cases", () => {
       languages[language] ??= [];
     }
 
-    for (const languageId of Object.keys(languages).sort()) {
+    for (const languageId of Object.keys(languages).toSorted()) {
       const tests = languages[languageId];
       test(`${languageId} facet coverage`, () =>
         testLanguageSupport(
@@ -91,7 +91,7 @@ function testLanguageSupport(languageId: string, testedFacets: string[]) {
     (testedFacet) => !supportedFacets.includes(testedFacet),
   );
   if (unsupportedFacets.length > 0) {
-    const values = uniq(unsupportedFacets).sort().join(", ");
+    const values = uniq(unsupportedFacets).toSorted().join(", ");
     assert.fail(
       `Facets [${values}] are tested but not listed in getLanguageScopeSupport`,
     );
@@ -102,7 +102,7 @@ function testLanguageSupport(languageId: string, testedFacets: string[]) {
     (supportedFacet) => !testedFacets.includes(supportedFacet),
   );
   if (untestedFacets.length > 0) {
-    const values = untestedFacets.sort().join(", ");
+    const values = untestedFacets.toSorted().join(", ");
     assert.fail(`Missing test for scope support facets [${values}]`);
   }
 }

--- a/packages/lib-engine/src/tokenizer/tokenizer.test.ts
+++ b/packages/lib-engine/src/tokenizer/tokenizer.test.ts
@@ -1,5 +1,5 @@
 import * as assert from "node:assert/strict";
-import { flatten, range } from "lodash-es";
+import { range } from "lodash-es";
 import { FakeIDE } from "@cursorless/lib-common";
 import { tokenize } from ".";
 
@@ -167,11 +167,9 @@ function getAsciiSymbols() {
     ["[", "`"],
     ["{", "~"],
   ];
-  return flatten(
-    rangesToTest.map(([start, end]) =>
-      range(start.codePointAt(0)!, end.codePointAt(0)! + 1).map((charCode) =>
-        String.fromCodePoint(charCode),
-      ),
+  return rangesToTest.flatMap(([start, end]) =>
+    range(start.codePointAt(0)!, end.codePointAt(0)! + 1).map((charCode) =>
+      String.fromCodePoint(charCode),
     ),
   );
 }

--- a/packages/lib-engine/src/util/allocateHats/getDisplayLineMap.ts
+++ b/packages/lib-engine/src/util/allocateHats/getDisplayLineMap.ts
@@ -17,7 +17,9 @@ export function getDisplayLineMap(
     ...editor.visibleRanges.flatMap((visibleRange) =>
       range(visibleRange.start.line, visibleRange.end.line + 1),
     ),
-  ]).toSorted((a, b) => a - b);
+  ]);
+
+  lines.sort((a, b) => a - b);
 
   return new Map(lines.map((value, index) => [value, index]));
 }

--- a/packages/lib-engine/src/util/allocateHats/getDisplayLineMap.ts
+++ b/packages/lib-engine/src/util/allocateHats/getDisplayLineMap.ts
@@ -17,7 +17,7 @@ export function getDisplayLineMap(
     ...editor.visibleRanges.flatMap((visibleRange) =>
       range(visibleRange.start.line, visibleRange.end.line + 1),
     ),
-  ]).sort((a, b) => a - b);
+  ]).toSorted((a, b) => a - b);
 
   return new Map(lines.map((value, index) => [value, index]));
 }

--- a/packages/lib-engine/src/util/allocateHats/getRankedTokens.ts
+++ b/packages/lib-engine/src/util/allocateHats/getRankedTokens.ts
@@ -1,4 +1,3 @@
-import { flatten } from "lodash-es";
 import type {
   CompositeKeyMap,
   IDE,
@@ -35,14 +34,12 @@ export function getRankedTokens(
      */
     const referencePosition = editor.selections[0].active;
     const displayLineMap = getDisplayLineMap(editor, [referencePosition.line]);
-    const tokens = flatten(
-      editor.visibleRanges.map((range) =>
-        // oxlint-disable-next-line oxc/no-map-spread
-        getTokensInRange(ide, editor, range).map((partialToken) => ({
-          ...partialToken,
-          displayLine: displayLineMap.get(partialToken.range.start.line)!,
-        })),
-      ),
+    const tokens = editor.visibleRanges.flatMap((range) =>
+      // oxlint-disable-next-line oxc/no-map-spread
+      getTokensInRange(ide, editor, range).map((partialToken) => ({
+        ...partialToken,
+        displayLine: displayLineMap.get(partialToken.range.start.line)!,
+      })),
     );
 
     tokens.sort(
@@ -69,7 +66,7 @@ function moveForcedHatsToFront(
     return tokens;
   }
 
-  return tokens.sort((a, b) => {
+  return tokens.toSorted((a, b) => {
     const aIsForced = forcedHatMap.has(a);
     const bIsForced = forcedHatMap.has(b);
     if (aIsForced && !bIsForced) {

--- a/packages/lib-engine/src/util/allocateHats/getRankedTokens.ts
+++ b/packages/lib-engine/src/util/allocateHats/getRankedTokens.ts
@@ -52,21 +52,21 @@ export function getRankedTokens(
     return tokens;
   });
 
-  return moveForcedHatsToFront(forcedHatMap, tokens).map((token, index) => ({
+  if (forcedHatMap != null) {
+    moveForcedHatsToFront(forcedHatMap, tokens);
+  }
+
+  return tokens.map((token, index) => ({
     token,
     rank: -index,
   }));
 }
 
 function moveForcedHatsToFront(
-  forcedHatMap: CompositeKeyMap<Token, TokenHat> | undefined,
+  forcedHatMap: CompositeKeyMap<Token, TokenHat>,
   tokens: Token[],
-) {
-  if (forcedHatMap == null) {
-    return tokens;
-  }
-
-  return tokens.toSorted((a, b) => {
+): void {
+  tokens.sort((a, b) => {
     const aIsForced = forcedHatMap.has(a);
     const bIsForced = forcedHatMap.has(b);
     if (aIsForced && !bIsForced) {

--- a/packages/lib-engine/src/util/allocateHats/getRankedTokens.ts
+++ b/packages/lib-engine/src/util/allocateHats/getRankedTokens.ts
@@ -35,7 +35,6 @@ export function getRankedTokens(
     const referencePosition = editor.selections[0].active;
     const displayLineMap = getDisplayLineMap(editor, [referencePosition.line]);
     const tokens = editor.visibleRanges.flatMap((range) =>
-      // oxlint-disable-next-line oxc/no-map-spread
       getTokensInRange(ide, editor, range).map((partialToken) => ({
         ...partialToken,
         displayLine: displayLineMap.get(partialToken.range.start.line)!,

--- a/packages/lib-engine/src/util/getMatchesInRange.ts
+++ b/packages/lib-engine/src/util/getMatchesInRange.ts
@@ -43,5 +43,6 @@ export function generateMatchesInRange(
 
   return direction === "forward"
     ? imap(text.matchAll(regex), matchToRange)
-    : Array.from(text.matchAll(regex), matchToRange).toReversed();
+    : // oxlint-disable-next-line unicorn/no-array-sort
+      Array.from(text.matchAll(regex), matchToRange).sort();
 }

--- a/packages/lib-engine/src/util/getMatchesInRange.ts
+++ b/packages/lib-engine/src/util/getMatchesInRange.ts
@@ -43,5 +43,5 @@ export function generateMatchesInRange(
 
   return direction === "forward"
     ? imap(text.matchAll(regex), matchToRange)
-    : Array.from(text.matchAll(regex), matchToRange).reverse();
+    : Array.from(text.matchAll(regex), matchToRange).toReversed();
 }

--- a/packages/lib-engine/src/util/getMatchesInRange.ts
+++ b/packages/lib-engine/src/util/getMatchesInRange.ts
@@ -43,6 +43,6 @@ export function generateMatchesInRange(
 
   return direction === "forward"
     ? imap(text.matchAll(regex), matchToRange)
-    : // oxlint-disable-next-line unicorn/no-array-sort
-      Array.from(text.matchAll(regex), matchToRange).sort();
+    : // oxlint-disable-next-line unicorn/no-array-reverse
+      Array.from(text.matchAll(regex), matchToRange).reverse();
 }

--- a/packages/lib-engine/src/util/unifyRanges.ts
+++ b/packages/lib-engine/src/util/unifyRanges.ts
@@ -7,7 +7,6 @@ export function unifyRemovalTargets(targets: Target[]): Target[] {
   if (targets.length < 2) {
     return targets;
   }
-  // oxlint-disable-next-line oxc/no-map-spread
   return groupTargetsForEachEditor(targets).flatMap(
     ([_editor, editorTargets]) => {
       if (editorTargets.length < 2) {

--- a/packages/tool-meta-updater/src/updatePackageJson.ts
+++ b/packages/tool-meta-updater/src/updatePackageJson.ts
@@ -119,7 +119,7 @@ function getScripts(
   };
 
   return Object.fromEntries(
-    Object.entries(scripts).sort(
+    Object.entries(scripts).toSorted(
       ([keyA], [keyB]) => getOrder(keyA) - getOrder(keyB),
     ),
   );
@@ -180,21 +180,21 @@ function sortFields(obj: Record<string, any>): Record<string, any> {
     "pnpm",
   ];
   const sorted = Object.fromEntries(
-    Object.entries(obj).sort(
+    Object.entries(obj).toSorted(
       ([keyA], [keyB]) => orderedKeys.indexOf(keyA) - orderedKeys.indexOf(keyB),
     ),
   );
 
   if (sorted.dependencies != null) {
     sorted.dependencies = Object.fromEntries(
-      Object.entries(sorted.dependencies).sort(([keyA], [keyB]) =>
+      Object.entries(sorted.dependencies).toSorted(([keyA], [keyB]) =>
         keyA.localeCompare(keyB),
       ),
     );
   }
   if (sorted.devDependencies != null) {
     sorted.devDependencies = Object.fromEntries(
-      Object.entries(sorted.devDependencies).sort(([keyA], [keyB]) =>
+      Object.entries(sorted.devDependencies).toSorted(([keyA], [keyB]) =>
         keyA.localeCompare(keyB),
       ),
     );

--- a/packages/tool-meta-updater/src/updatesScopeSupportFacetInfos.ts
+++ b/packages/tool-meta-updater/src/updatesScopeSupportFacetInfos.ts
@@ -22,7 +22,7 @@ export function updatesScopeSupportFacetInfos(
     ...plaintextScopeSupportFacetInfos,
   };
 
-  const facets = Object.keys(facetsInfos).sort();
+  const facets = Object.keys(facetsInfos).toSorted();
   const rows: string[] = [];
   let currentScopeType: string | null = null;
 


### PR DESCRIPTION
Still keeps .sort and .reverse in performance critical areas