### PR TITLE
Prevent Lua injection in Neovim error notifications

### DIFF
--- a/packages/lib-neovim-common/src/neovimApi.ts
+++ b/packages/lib-neovim-common/src/neovimApi.ts
@@ -164,6 +164,6 @@ export async function showErrorMessage(
   client: NeovimClient,
   message: string,
 ): Promise<void> {
-  const luaCode = `vim.notify("${message}")`;
-  await client.executeLua(luaCode, []);
+  const luaCode = "vim.notify(...)";
+  await client.executeLua(luaCode, [message]);
 }


### PR DESCRIPTION
### Motivation
- Prevent execution of attacker-controlled Lua by removing string interpolation of error messages into generated Lua code for Neovim notifications.

### Description
- Replace unsafe interpolation in `showErrorMessage` with an argument-bound call by using `vim.notify(...)` as the Lua snippet and passing the `message` via `executeLua` arguments so user text is treated as data.

### Testing
- Ran the repository lint suite with `pnpm run lint`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a285bb2708333beb624ab75faffbd)