### PR TITLE
Fixed capitalization in sidebar elements

### DIFF
--- a/packages/app-web-docs/src/docs/contributing/architecture/_category_.json
+++ b/packages/app-web-docs/src/docs/contributing/architecture/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Architecture"
+}

--- a/packages/app-web-docs/src/docs/user/experimental/keyboard/_category_.json
+++ b/packages/app-web-docs/src/docs/user/experimental/keyboard/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Keyboard"
+}

--- a/packages/app-web-docs/src/docs/user/reference/_category_.json
+++ b/packages/app-web-docs/src/docs/user/reference/_category_.json
@@ -1,0 +1,3 @@
+{
+  "label": "Reference"
+}


### PR DESCRIPTION
BEFORE:
<img width="291" height="597" alt="image" src="https://github.com/user-attachments/assets/2a21d929-d73d-4151-9efb-9cfa2aa202c6" />

AFTER:
<img width="294" height="589" alt="image" src="https://github.com/user-attachments/assets/f3455467-0018-45d0-8a00-9271cf060c07" />

Same for other elements changed

Needed to do it in `_category_.json` and not in `README.MD` because else docusaurus would create a page for those sidebar entries which would change the behavior